### PR TITLE
Inject behaviour in test center to enable assigned sync manager

### DIFF
--- a/controller/SyncManagerTree.php
+++ b/controller/SyncManagerTree.php
@@ -61,7 +61,7 @@ class SyncManagerTree extends \tao_actions_CommonModule
     protected function saveReversedValues(\core_kernel_classes_Resource $testCenter, array $values)
     {
         $id = $this->getTestCenterOrganisationId($testCenter);
-        $assignedSyncUserProperty = $this->getProperty(SyncService::ASSIGNED_SYNC_USER);
+        $assignedSyncUserProperty = $this->getProperty(SyncService::PROPERTY_ASSIGNED_SYNC_USER);
         $organisationIdProperty = $this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY);
 
         $success = true;

--- a/controller/SyncManagerTree.php
+++ b/controller/SyncManagerTree.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA
+ */
+
+namespace oat\taoSync\controller;
+
+
+use oat\generis\model\OntologyAwareTrait;
+use oat\taoSync\model\synchronizer\custom\byOrganisationId\testcenter\TestCenterByOrganisationId;
+use oat\taoSync\model\SyncService;
+
+class SyncManagerTree extends \tao_actions_CommonModule
+{
+    use OntologyAwareTrait;
+
+    /**
+     * Entrypoint to save the value sent form the form
+     *
+     * @throws \common_Exception
+     * @throws \common_exception_IsAjaxAction
+     * @throws \core_kernel_persistence_Exception
+     */
+    public function setReverseValues()
+    {
+        if (!\tao_helpers_Request::isAjax()) {
+            throw new \common_exception_IsAjaxAction(__FUNCTION__);
+        }
+
+        $values = \tao_helpers_form_GenerisTreeForm::getSelectedInstancesFromPost();
+        $resource = $this->getResource($this->getRequestParameter('resourceUri'));
+
+        $success = $this->saveReversedValues($resource, $values);
+
+        echo json_encode(array('saved' => $success));
+    }
+
+    /**
+     * Save the values sent from the SyncUser form
+     *
+     * @param \core_kernel_classes_Resource $testCenter
+     * @param array $values
+     * @return bool
+     * @throws \common_Exception
+     * @throws \core_kernel_persistence_Exception
+     */
+    protected function saveReversedValues(\core_kernel_classes_Resource $testCenter, array $values)
+    {
+        $id = $this->getTestCenterOrganisationId($testCenter);
+        $assignedSyncUserProperty = $this->getProperty(SyncService::ASSIGNED_SYNC_USER);
+        $organisationIdProperty = $this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY);
+
+        $success = true;
+        foreach ($values as $uri) {
+            $syncUser = $this->getResource($uri);
+            $success = $success && $syncUser->editPropertyValues($assignedSyncUserProperty, $testCenter);
+            $success = $success && $syncUser->editPropertyValues($organisationIdProperty, $id);
+        }
+
+        return $success;
+    }
+
+    /**
+     * Get the organisation id property of a test center
+     *
+     * @param \core_kernel_classes_Resource $testCenter
+     * @return string
+     * @throws \common_Exception
+     * @throws \core_kernel_persistence_Exception
+     */
+    protected function getTestCenterOrganisationId(\core_kernel_classes_Resource $testCenter)
+    {
+        $property = $testCenter->getOnePropertyValue($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
+        if (is_null($property)) {
+            throw new \common_Exception(__('TestCenter must have an organisation id property to associate it to sync manager(s).'));
+        }
+        return $property->literal;
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -30,9 +30,9 @@ return array(
     'version' => '1.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao' => '>=19.10.0',
+        'tao' => '>=19.21.0',
         'taoOauth' => '>=1.0.3',
-        'taoTestCenter' => '>=3.7.0',
+        'taoTestCenter' => '>=3.15.0',
         'taoResultServer' => '>=6.4.0',
         'taoTaskQueue' => '>=0.17.0',
         'taoDeliveryRdf' => '>=4.8.0',

--- a/manifest.php
+++ b/manifest.php
@@ -30,6 +30,7 @@ return array(
     'version' => '1.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
+        'generis' => '>=7.9.5',
         'tao' => '>=19.21.0',
         'taoOauth' => '>=1.0.3',
         'taoTestCenter' => '>=3.15.0',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '1.5.0',
+    'version' => '1.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=19.10.0',

--- a/model/SyncService.php
+++ b/model/SyncService.php
@@ -46,6 +46,7 @@ class SyncService extends ConfigurableService
     const SERVICE_ID = 'taoSync/syncService';
     const TAO_SYNC_ROLE = 'http://www.tao.lu/Ontologies/generis.rdf#taoSyncManager';
     const PROPERTY_CONSUMER_USER = 'http://www.tao.lu/Ontologies/taoSync.rdf#ConsumerUser';
+    const ASSIGNED_SYNC_USER = 'http://www.taotesting.com/Ontologies/TAOTestCenter.rdf#assignedSyncUser';
 
     const OPTION_SYNCHRONIZERS = 'synchronizers';
     const OPTION_CHUNK_SIZE = 'chunkSize';

--- a/model/SyncService.php
+++ b/model/SyncService.php
@@ -46,7 +46,7 @@ class SyncService extends ConfigurableService
     const SERVICE_ID = 'taoSync/syncService';
     const TAO_SYNC_ROLE = 'http://www.tao.lu/Ontologies/generis.rdf#taoSyncManager';
     const PROPERTY_CONSUMER_USER = 'http://www.tao.lu/Ontologies/taoSync.rdf#ConsumerUser';
-    const ASSIGNED_SYNC_USER = 'http://www.taotesting.com/Ontologies/TAOTestCenter.rdf#assignedSyncUser';
+    const PROPERTY_ASSIGNED_SYNC_USER = 'http://www.taotesting.com/Ontologies/TAOTestCenter.rdf#assignedSyncUser';
 
     const OPTION_SYNCHRONIZERS = 'synchronizers';
     const OPTION_CHUNK_SIZE = 'chunkSize';

--- a/model/listener/ListenerService.php
+++ b/model/listener/ListenerService.php
@@ -169,9 +169,4 @@ class ListenerService extends ConfigurableService
         return $this->getServiceLocator()->get(DeliverySynchronizerService::SERVICE_ID);
     }
 
-    public function onResourceDeleted(ResourceDeleted $event)
-    {
-    }
-
-
 }

--- a/model/listener/ListenerService.php
+++ b/model/listener/ListenerService.php
@@ -131,7 +131,7 @@ class ListenerService extends ConfigurableService
 
         $queryBuilder = $search->query();
         $query = $search->searchType($queryBuilder, TaoOntology::CLASS_URI_TAO_USER, true);
-        $query->add(SyncService::ASSIGNED_SYNC_USER)->equals($event->getResource()->getUri());
+        $query->add(SyncService::PROPERTY_ASSIGNED_SYNC_USER)->equals($event->getResource()->getUri());
         $queryBuilder->setCriteria($query);
 
         try {

--- a/model/ui/SyncUserFormFactory.php
+++ b/model/ui/SyncUserFormFactory.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoSync\model\ui;
+
+use oat\generis\model\user\UserRdf;
+use oat\taoSync\model\SyncService;
+use oat\taoTestCenter\model\gui\form\formFactory\FormFactory;
+
+/**
+ * Class SyncUserFormFactory
+ *
+ * Generate a form for assignation of SyncManager to test center
+ *
+ * @package oat\taoSync\model\ui
+ */
+class SyncUserFormFactory extends FormFactory
+{
+    /**
+     * Set the form url according to SyncManagerTree
+     *
+     * @param \core_kernel_classes_Resource $testCenter
+     * @return mixed
+     */
+    public function __invoke(\core_kernel_classes_Resource $testCenter)
+    {
+        $form = parent::__invoke($testCenter);
+        $form->setData('saveUrl', _url('setReverseValues', 'SyncManagerTree', 'taoSync'));
+        $form->setData('dataUrl', _url(
+            'getData', 'GenerisTree', 'tao',
+            http_build_query(['filterProperties' => [
+                UserRdf::PROPERTY_ROLES => [SyncService::TAO_SYNC_ROLE]
+            ]])
+        ));
+        return $form;
+    }
+
+}

--- a/scripts/install/SetupAssignedTestCenterSyncUser.php
+++ b/scripts/install/SetupAssignedTestCenterSyncUser.php
@@ -20,6 +20,7 @@
 namespace oat\taoSync\scripts\install;
 
 use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdfs;
 use oat\oatbox\extension\InstallAction;
 use oat\tao\model\event\MetadataModified;
 use oat\tao\model\TaoOntology;
@@ -57,7 +58,7 @@ class SetupAssignedTestCenterSyncUser extends InstallAction
      */
     protected function registerTestCenterSyncUserProperty()
     {
-        $property = $this->getProperty(SyncService::ASSIGNED_SYNC_USER);
+        $property = $this->getProperty(SyncService::PROPERTY_ASSIGNED_SYNC_USER);
 
         if ($property->exists()) {
             return;
@@ -69,8 +70,8 @@ class SetupAssignedTestCenterSyncUser extends InstallAction
         $property->setLabel('Assigned sync user');
         $property->setComment('Assign sync user to the test center');
         $property->setPropertyValue(
-            $this->getProperty('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
-            'http://www.w3.org/2000/01/rdf-schema#member'
+            $this->getProperty(OntologyRdfs::RDFS_SUBPROPERTYOF),
+            TestCenterService::PROPERTY_MEMBER
         );
     }
 
@@ -89,14 +90,14 @@ class SetupAssignedTestCenterSyncUser extends InstallAction
 
         $alreadySet = false;
         foreach ($formFactoryOptions as $factory) {
-            if ($factory->hasOption('property') && $factory->getOption('property') == SyncService::ASSIGNED_SYNC_USER) {
+            if ($factory->hasOption('property') && $factory->getOption('property') == SyncService::PROPERTY_ASSIGNED_SYNC_USER) {
                 $alreadySet = true;
             }
         }
 
         if (!$alreadySet) {
             array_splice($formFactoryOptions, 2, 0, [new SyncUserFormFactory([
-                'property' => SyncService::ASSIGNED_SYNC_USER,
+                'property' => SyncService::PROPERTY_ASSIGNED_SYNC_USER,
                 'title' => __('Assign Sync Manager'),
                 'isReversed' => true,
             ])]);

--- a/scripts/install/SetupAssignedTestCenterSyncUser.php
+++ b/scripts/install/SetupAssignedTestCenterSyncUser.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA
+ */
+
+namespace oat\taoSync\scripts\install;
+
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\event\MetadataModified;
+use oat\tao\model\TaoOntology;
+use oat\taoSync\model\listener\ListenerService;
+use oat\taoSync\model\SyncService;
+use oat\taoSync\model\ui\SyncUserFormFactory;
+use oat\taoTestCenter\model\gui\form\TreeFormFactory;
+use oat\taoTestCenter\model\TestCenterService;
+
+class SetupAssignedTestCenterSyncUser extends InstallAction
+{
+    use OntologyAwareTrait;
+
+    /**
+     * Register the form for SyncUserAssigned in testcenter edit
+     *
+     * @param $params
+     * @return \common_report_Report
+     * @throws \common_Exception
+     */
+    public function __invoke($params)
+    {
+        try {
+            $this->registerTestCenterSyncUserProperty();
+            $this->registerTestCenterSyncUserForm();
+            $this->registerTestCenterOrgIdUpdatedEvent();
+            return \common_report_Report::createSuccess('SyncUserAssigned property for testcenter has been successfully set.');
+        } catch (\Exception $e) {
+            return \common_report_Report::createFailure('SyncUserAssigned property for testcenter has failed with message "' . $e->getMessage() . '".');
+        }
+    }
+
+    /**
+     * Register the property for TestCenterSyncUserAssigned
+     */
+    protected function registerTestCenterSyncUserProperty()
+    {
+        $property = $this->getProperty(SyncService::ASSIGNED_SYNC_USER);
+
+        if ($property->exists()) {
+            return;
+        }
+
+        $property->setRange($this->getClass(TestCenterService::ROLE_TESTCENTER_MANAGER));
+        $property->setMultiple(true);
+        $property->setDomain($this->getClass(TaoOntology::CLASS_URI_TAO_USER));
+        $property->setLabel('Assigned sync user');
+        $property->setComment('Assign sync user to the test center');
+        $property->setPropertyValue(
+            $this->getProperty('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
+            'http://www.w3.org/2000/01/rdf-schema#member'
+        );
+    }
+
+    /**
+     * Register TestCenter SyncUserAssigned Form
+     *
+     * @throws \common_Exception
+     */
+    protected function registerTestCenterSyncUserForm()
+    {
+        /** @var TreeFormFactory $treeFormFactory */
+        $treeFormFactory = $this->getServiceLocator()->get(TreeFormFactory::SERVICE_ID);
+        $formFactoryOptions = $treeFormFactory->hasOption(TreeFormFactory::OPTION_FORM_FACTORIES)
+            ? $treeFormFactory->getOption(TreeFormFactory::OPTION_FORM_FACTORIES)
+            : [];
+
+        $alreadySet = false;
+        foreach ($formFactoryOptions as $factory) {
+            if ($factory->hasOption('property') && $factory->getOption('property') == SyncService::ASSIGNED_SYNC_USER) {
+                $alreadySet = true;
+            }
+        }
+
+        if (!$alreadySet) {
+            array_splice($formFactoryOptions, 2, 0, [new SyncUserFormFactory([
+                'property' => SyncService::ASSIGNED_SYNC_USER,
+                'title' => __('Assign Sync Manager'),
+                'isReversed' => true,
+            ])]);
+            $treeFormFactory->setOption(TreeFormFactory::OPTION_FORM_FACTORIES, $formFactoryOptions);
+            $this->registerService(TreeFormFactory::SERVICE_ID, $treeFormFactory);
+        }
+    }
+
+    /**
+     * Register the MetadataModifiedEvent to change assigned users to TestCenter
+     */
+    protected function registerTestCenterOrgIdUpdatedEvent()
+    {
+        $this->registerEvent(MetadataModified::class, [ListenerService::SERVICE_ID, 'listen']);
+    }
+}

--- a/scripts/tool/CreateAssignedSyncUserByOrgId.php
+++ b/scripts/tool/CreateAssignedSyncUserByOrgId.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace oat\taoSync\scripts\tool;
+
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\AbstractAction;
+use oat\search\base\exception\SearchGateWayExeption;
+use oat\tao\model\TaoOntology;
+use oat\taoSync\model\synchronizer\custom\byOrganisationId\testcenter\TestCenterByOrganisationId;
+use oat\taoSync\model\SyncService;
+use oat\taoTestCenter\model\TestCenterService;
+
+class CreateAssignedSyncUserByOrgId extends AbstractAction
+{
+    use OntologyAwareTrait;
+
+    public function __invoke($params)
+    {
+        $testCenters = $this->getClass(TestCenterService::CLASS_URI)->getInstances(true);
+        $assignedSyncUserProperty = $this->getProperty(SyncService::PROPERTY_ASSIGNED_SYNC_USER);
+        $i = 0;
+        $success = true;
+
+        /** @var \core_kernel_classes_Resource $testCenter */
+        foreach ($testCenters as $testCenter) {
+
+            $id = $testCenter->getOnePropertyValue($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
+            if (is_null($id)) {
+                continue;
+            }
+
+            /** @var ComplexSearchService $search */
+            $search = $this->getServiceLocator()->get(ComplexSearchService::SERVICE_ID);
+            $queryBuilder = $search->query();
+            $query = $search->searchType($queryBuilder, TaoOntology::CLASS_URI_TAO_USER, true);
+            $query->add(GenerisRdf::PROPERTY_USER_ROLES)->equals(SyncService::TAO_SYNC_ROLE);
+            $query->add(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY)->equals($id);
+            $queryBuilder->setCriteria($query);
+
+            try {
+                $results = $search->getGateway()->search($queryBuilder);
+                if ($results->total() > 0) {
+                    foreach ($results as $syncUser) {
+                        $success = $success && $syncUser->editPropertyValues($assignedSyncUserProperty, $testCenter);
+                        $i++;
+                    }
+                }
+            } catch (SearchGateWayExeption $e) {}
+        }
+
+        if ($success) {
+            return \common_report_Report::createSuccess($i . ' sync users have been successfully assigned to test centers');
+        } else {
+            return \common_report_Report::createFailure('An error has occurred during sync users migration.');
+        }
+    }
+
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -386,7 +386,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('1.4.0');
         }
 
-        $this->skip('1.4.0', '1.5.0');
+        $this->skip('1.4.0', '1.6.0');
     }
 
     /**


### PR DESCRIPTION
Requires https://github.com/oat-sa/tao-core/pull/1799
Requires https://github.com/oat-sa/extension-tao-testcenter/pull/76

To enable sync user assignment do : 
`php index.php '\oat\taoSync\scripts\install\SetupAssignedTestCenterSyncUser'`