### PR TITLE
Feature/tao 7191/create synchronization events and listeners

### DIFF
--- a/config/default/SyncLogDataParser.conf.php
+++ b/config/default/SyncLogDataParser.conf.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
+
+return new SyncLogDataParser([]);

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '3.2.0',
+    'version' => '3.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '3.3.0',
+    'version' => '3.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/SyncLog/SyncLogDataHelper.php
+++ b/model/SyncLog/SyncLogDataHelper.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\SyncLog;
+
+/**
+ * Class SyncLogDataHelper
+ * @package oat\taoSync\model\SyncLog
+ */
+class SyncLogDataHelper
+{
+    /**
+     * Merge synchronization log data.
+     *
+     * @param array $initialData
+     * @param array $newData
+     * @return array
+     */
+    public static function mergeSyncData($initialData = [], array $newData)
+    {
+        if (!is_array($initialData)) {
+            $initialData = is_null($initialData) ? [] : [$initialData];
+        }
+
+        foreach ($newData as $entityName => $entityData) {
+            if (!is_array($entityData)) {
+                continue;
+            }
+
+            foreach ($entityData as $action => $amount) {
+                $currentAmount = isset($initialData[$entityName][$action]) ? $initialData[$entityName][$action] : 0;
+
+                $initialData[$entityName][$action] = $currentAmount + $amount;
+            }
+        }
+
+        return $initialData;
+    }
+}

--- a/model/SyncLog/SyncLogDataParser.php
+++ b/model/SyncLog/SyncLogDataParser.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\SyncLog;
+
+
+use oat\oatbox\service\ConfigurableService;
+use common_report_Report as Report;
+
+/**
+ * Class SyncLogDataParser
+ * @package oat\taoSync\model\SyncLog
+ */
+class SyncLogDataParser extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/SyncLogDataParser';
+
+    private $parsedData = [];
+
+    /**
+     * @param Report $report
+     * @return array
+     */
+    public function parseSyncData(Report $report) {
+        $this->parsedData = [];
+
+        $this->parseSynchronizedEntities($report);
+
+        return $this->parsedData;
+    }
+
+    /**
+     * @param Report $report
+     */
+    private function parseSynchronizedEntities(Report $report) {
+        if ($report->hasChildren()) {
+            foreach ($report->getIterator() as $child) {
+                $this->parseSynchronizedEntities($child);
+            }
+        }
+
+        $reportData = $report->getData() ? $report->getData() : [];
+
+        $this->parsedData = SyncLogDataHelper::mergeSyncData($this->parsedData, $reportData);
+    }
+}

--- a/model/client/SynchronisationClient.php
+++ b/model/client/SynchronisationClient.php
@@ -215,6 +215,22 @@ class SynchronisationClient extends ConfigurableService
     }
 
     /**
+     * Send confirmation to the central server about completed synchronization on the client.
+     *
+     * @param array $syncParams
+     * @return array
+     * @throws \common_Exception
+     */
+    public function sendSyncFinishedConfirmation(array $syncParams)
+    {
+        $url = '/taoSync/SynchronisationApi/confirmSyncFinished';
+        $method = \Request::HTTP_POST;
+        $response = $this->call($url, $method, json_encode([SynchronisationApi::PARAM_PARAMETERS => $syncParams]));
+
+        return $this->decodeResponseBody($response);
+    }
+
+    /**
      * json_decode the body content of given response
      *
      * Parse error to have a readable message if http code is not 2**

--- a/model/event/AbstractSyncEvent.php
+++ b/model/event/AbstractSyncEvent.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+use common_report_Report as Report;
+use oat\oatbox\event\Event;
+
+/**
+ * Class AbstractSyncEvent
+ * @package oat\taoSync\model\event
+ */
+abstract class AbstractSyncEvent implements Event
+{
+    /**
+     * @var array
+     */
+    private $syncParameters = [];
+
+    /**
+     * @var Report
+     */
+    private $report = null;
+
+    /**
+     * SynchronizationStarted constructor.
+     * @param $syncParameters
+     * @param Report $report
+     */
+    public function __construct($syncParameters, Report $report)
+    {
+        $this->syncParameters = $syncParameters;
+        $this->report = $report;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return static::class;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSyncParameters()
+    {
+        return $this->syncParameters;
+    }
+
+    /**
+     * @return Report
+     */
+    public function getReport()
+    {
+        return $this->report;
+    }
+}

--- a/model/event/SyncFailedEvent.php
+++ b/model/event/SyncFailedEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+/**
+ * Class SyncFailedEvent
+ * @package oat\taoSync\model\event
+ */
+class SyncFailedEvent extends AbstractSyncEvent {}

--- a/model/event/SyncFinishedEvent.php
+++ b/model/event/SyncFinishedEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+/**
+ * Class SyncFinishedEvent
+ * @package oat\taoSync\model\event
+ */
+class SyncFinishedEvent extends AbstractSyncEvent {}

--- a/model/event/SyncRequestEvent.php
+++ b/model/event/SyncRequestEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+/**
+ * Class SyncRequestEvent
+ * @package oat\taoSync\model\event
+ */
+class SyncRequestEvent extends AbstractSyncEvent {}

--- a/model/event/SyncResponseEvent.php
+++ b/model/event/SyncResponseEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+/**
+ * Class SyncResponseEvent
+ * @package oat\taoSync\model\event
+ */
+class SyncResponseEvent extends AbstractSyncEvent {}

--- a/model/event/SyncStartedEvent.php
+++ b/model/event/SyncStartedEvent.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\event;
+
+/**
+ * Class SyncStartedEvent
+ * @package oat\taoSync\model\event
+ */
+class SyncStartedEvent extends AbstractSyncEvent {}

--- a/model/listener/CentralSyncLogListener.php
+++ b/model/listener/CentralSyncLogListener.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\listener;
+
+use DateTime;
+use common_report_Report as Report;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoSync\model\event\AbstractSyncEvent;
+use oat\taoSync\model\event\SyncFinishedEvent;
+use oat\taoSync\model\event\SyncRequestEvent;
+use oat\taoSync\model\event\SyncResponseEvent;
+use oat\taoSync\model\Exception\SyncLogEntityNotFound;
+use oat\taoSync\model\SyncLog\SyncLogDataHelper;
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
+use oat\taoSync\model\SyncLog\SyncLogEntity;
+use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
+
+/**
+ * Class CentralSyncLogListener
+ * @package oat\taoSync\model\listener
+ */
+class CentralSyncLogListener extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/CentralSyncLogListener';
+
+    /**
+     * Handler synchronization request event.
+     *
+     * @param SyncRequestEvent $event
+     */
+    public function logSyncRequest(SyncRequestEvent $event)
+    {
+        try {
+            $this->updateSyncLogRecord($event);
+        } catch (SyncLogEntityNotFound $e) {
+            $params = $event->getSyncParameters();
+            $this->validateParameters($params);
+            $syncLogService = $this->getSyncLogService();
+
+            $report = Report::createInfo('Synchronization started...');
+            $report->add($event->getReport());
+            $syncLogEntity = new SyncLogEntity(
+                $params[SyncLogServiceInterface::PARAM_SYNC_ID],
+                $params[SyncLogServiceInterface::PARAM_BOX_ID],
+                $params[SyncLogServiceInterface::PARAM_ORGANIZATION_ID],
+                $this->parseSyncData($report),
+                SyncLogEntity::STATUS_IN_PROGRESS,
+                $report,
+                new DateTime()
+            );
+
+            $syncLogService->create($syncLogEntity);
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+
+    /**
+     * Handle synchronization response event.
+     *
+     * @param SyncResponseEvent $event
+     */
+    public function logSyncResponse(SyncResponseEvent $event)
+    {
+        try {
+            $this->updateSyncLogRecord($event);
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+
+    /**
+     * Update synchronization response record.
+     *
+     * @param AbstractSyncEvent $event
+     * @throws \common_exception_Error
+     */
+    private function updateSyncLogRecord(AbstractSyncEvent $event)
+    {
+        $params = $event->getSyncParameters();
+        $this->validateParameters($params);
+        $syncLogService = $this->getSyncLogService();
+
+        /** @var SyncLogEntity $syncLogEntity */
+        $syncLogEntity = $syncLogService->getBySyncIdAndBoxId($params[SyncLogServiceInterface::PARAM_SYNC_ID], $params[SyncLogServiceInterface::PARAM_BOX_ID]);
+
+        $report = $syncLogEntity->getReport();
+        $report->add($event->getReport());
+
+        $eventData = $this->parseSyncData($event->getReport());
+        $newSyncData = SyncLogDataHelper::mergeSyncData($syncLogEntity->getData(), $eventData);
+        $syncLogEntity->setData($newSyncData);
+
+        $syncLogService->update($syncLogEntity);
+    }
+
+    /**
+     * @param SyncFinishedEvent $event
+     */
+    public function logSyncFinished(SyncFinishedEvent $event)
+    {
+        try {
+            $params = $event->getSyncParameters();
+            $this->validateParameters($params);
+            $syncLogService = $this->getSyncLogService();
+
+            /** @var SyncLogEntity $syncLogEntity */
+            $syncLogEntity = $syncLogService->getBySyncIdAndBoxId($params[SyncLogServiceInterface::PARAM_SYNC_ID], $params[SyncLogServiceInterface::PARAM_BOX_ID]);
+
+            $report = $syncLogEntity->getReport();
+            $report->add($event->getReport());
+            if ($report->containsError()) {
+                $syncLogEntity->setFailed();
+            } else {
+                $syncLogEntity->setCompleted();
+            }
+            $syncLogEntity->setFinishTime(new DateTime());
+
+            $syncLogService->update($syncLogEntity);
+        } catch (\Exception $e) {
+            return;
+        }
+    }
+
+    /**
+     * @param array $params
+     * @return bool
+     */
+    private function validateParameters(array $params)
+    {
+        if (empty($params[SyncLogServiceInterface::PARAM_SYNC_ID])) {
+            throw new \InvalidArgumentException('Required synchronization parameter is missing: ' . SyncLogServiceInterface::PARAM_SYNC_ID);
+        }
+        if (empty($params[SyncLogServiceInterface::PARAM_BOX_ID])) {
+            throw new \InvalidArgumentException('Required synchronization parameter is missing: ' . SyncLogServiceInterface::PARAM_BOX_ID);
+        }
+        if (empty($params[SyncLogServiceInterface::PARAM_ORGANIZATION_ID])) {
+            throw new \InvalidArgumentException('Required synchronization parameter is missing: ' . SyncLogServiceInterface::PARAM_ORGANIZATION_ID);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Report $report
+     * @return array
+     */
+    private function parseSyncData(Report $report)
+    {
+        /** @var SyncLogDataParser $formatter */
+        $formatter = $this->getServiceLocator()->get(SyncLogDataParser::SERVICE_ID);
+
+        return $formatter->parseSyncData($report);
+    }
+
+    /**
+     * @return SyncLogServiceInterface
+     */
+    private function getSyncLogService()
+    {
+        return $this->getServiceLocator()->get(SyncLogServiceInterface::SERVICE_ID);
+    }
+}

--- a/model/listener/CentralSyncLogListener.php
+++ b/model/listener/CentralSyncLogListener.php
@@ -20,6 +20,8 @@
 namespace oat\taoSync\model\listener;
 
 use DateTime;
+use Exception;
+use common_exception_Error;
 use common_report_Report as Report;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoSync\model\event\AbstractSyncEvent;
@@ -50,24 +52,8 @@ class CentralSyncLogListener extends ConfigurableService
         try {
             $this->updateSyncLogRecord($event);
         } catch (SyncLogEntityNotFound $e) {
-            $params = $event->getSyncParameters();
-            $this->validateParameters($params);
-            $syncLogService = $this->getSyncLogService();
-
-            $report = Report::createInfo('Synchronization started...');
-            $report->add($event->getReport());
-            $syncLogEntity = new SyncLogEntity(
-                $params[SyncLogServiceInterface::PARAM_SYNC_ID],
-                $params[SyncLogServiceInterface::PARAM_BOX_ID],
-                $params[SyncLogServiceInterface::PARAM_ORGANIZATION_ID],
-                $this->parseSyncData($report),
-                SyncLogEntity::STATUS_IN_PROGRESS,
-                $report,
-                new DateTime()
-            );
-
-            $syncLogService->create($syncLogEntity);
-        } catch (\Exception $e) {
+            $this->createSyncLogRecord($event);
+        } catch (Exception $e) {
             $this->logError($e->getMessage());
         }
     }
@@ -81,7 +67,7 @@ class CentralSyncLogListener extends ConfigurableService
     {
         try {
             $this->updateSyncLogRecord($event);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logError($e->getMessage());
         }
     }
@@ -90,7 +76,7 @@ class CentralSyncLogListener extends ConfigurableService
      * Update synchronization response record.
      *
      * @param AbstractSyncEvent $event
-     * @throws \common_exception_Error
+     * @throws common_exception_Error
      */
     private function updateSyncLogRecord(AbstractSyncEvent $event)
     {
@@ -109,6 +95,33 @@ class CentralSyncLogListener extends ConfigurableService
         $syncLogEntity->setData($newSyncData);
 
         $syncLogService->update($syncLogEntity);
+    }
+
+    /**
+     * Create synchronization log record.
+     *
+     * @param SyncRequestEvent $event
+     * @throws common_exception_Error
+     */
+    private function createSyncLogRecord(SyncRequestEvent $event)
+    {
+        $params = $event->getSyncParameters();
+        $this->validateParameters($params);
+        $syncLogService = $this->getSyncLogService();
+
+        $report = Report::createInfo('Synchronization started...');
+        $report->add($event->getReport());
+        $syncLogEntity = new SyncLogEntity(
+            $params[SyncLogServiceInterface::PARAM_SYNC_ID],
+            $params[SyncLogServiceInterface::PARAM_BOX_ID],
+            $params[SyncLogServiceInterface::PARAM_ORGANIZATION_ID],
+            $this->parseSyncData($report),
+            SyncLogEntity::STATUS_IN_PROGRESS,
+            $report,
+            new DateTime()
+        );
+
+        $syncLogService->create($syncLogEntity);
     }
 
     /**
@@ -134,7 +147,7 @@ class CentralSyncLogListener extends ConfigurableService
             $syncLogEntity->setFinishTime(new DateTime());
 
             $syncLogService->update($syncLogEntity);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return;
         }
     }

--- a/model/listener/CentralSyncLogListener.php
+++ b/model/listener/CentralSyncLogListener.php
@@ -148,7 +148,7 @@ class CentralSyncLogListener extends ConfigurableService
 
             $syncLogService->update($syncLogEntity);
         } catch (Exception $e) {
-            return;
+            $this->logError($e->getMessage());
         }
     }
 

--- a/model/listener/ClientSyncLogListener.php
+++ b/model/listener/ClientSyncLogListener.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\listener;
+
+use DateTime;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoSync\model\event\SyncFailedEvent;
+use oat\taoSync\model\event\SyncFinishedEvent;
+use oat\taoSync\model\event\SyncStartedEvent;
+use oat\taoSync\model\SyncLog\SyncLogDataHelper;
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
+use oat\taoSync\model\SyncLog\SyncLogEntity;
+use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
+
+/**
+ * Class ClientSyncLogListener
+ * @package oat\taoSync\model\listener
+ */
+class ClientSyncLogListener extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/ClientSyncLogListener';
+
+    /**
+     * Create log record about started synchronization.
+     *
+     * @param SyncStartedEvent $event
+     */
+    public function logSyncStarted(SyncStartedEvent $event)
+    {
+        try {
+            $syncLogService = $this->getSyncLogService();
+            $params = $event->getSyncParameters();
+            $syncLogEntity = new SyncLogEntity(
+                $params[SyncLogServiceInterface::PARAM_SYNC_ID],
+                $params[SyncLogServiceInterface::PARAM_BOX_ID],
+                $params[SyncLogServiceInterface::PARAM_ORGANIZATION_ID],
+                $this->parseSyncData($event->getReport()),
+                SyncLogEntity::STATUS_IN_PROGRESS,
+                $event->getReport(),
+                new DateTime()
+            );
+
+            $syncLogService->create($syncLogEntity);
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+
+    /**
+     * Update log record for finished synchronization.
+     *
+     * @param SyncFinishedEvent $event
+     */
+    public function logSyncFinished(SyncFinishedEvent $event)
+    {
+        try {
+            $parameters = $event->getSyncParameters();
+            $syncLogEntity = $this->getSyncLogService()->getBySyncIdAndBoxId($parameters['sync_id'], $parameters['box_id']);
+
+            $report = $syncLogEntity->getReport();
+            $report->add($event->getReport());
+            if ($report->containsError()) {
+                $syncLogEntity->setFailed();
+            } else {
+                $syncLogEntity->setCompleted();
+            }
+            $eventData = $this->parseSyncData($event->getReport());
+            $newSyncData = SyncLogDataHelper::mergeSyncData($syncLogEntity->getData(), $eventData);
+
+            $syncLogEntity->setData($newSyncData);
+            $syncLogEntity->setFinishTime(new DateTime());
+
+            $this->getSyncLogService()->update($syncLogEntity);
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+
+    /**
+     * Update log record for failed synchronization.
+     *
+     * @param SyncFailedEvent $event
+     */
+    public function logSyncFailed(SyncFailedEvent $event)
+    {
+        try {
+            $parameters = $event->getSyncParameters();
+            $syncId = $parameters[SyncLogServiceInterface::PARAM_SYNC_ID];
+            $boxId = $parameters[SyncLogServiceInterface::PARAM_BOX_ID];
+            $syncLogEntity = $this->getSyncLogService()->getBySyncIdAndBoxId($syncId, $boxId);
+
+            $report = $syncLogEntity->getReport();
+            $report->add($event->getReport());
+
+            $eventData = $this->parseSyncData($event->getReport());
+            $newSyncData = SyncLogDataHelper::mergeSyncData($syncLogEntity->getData(), $eventData);
+
+            $syncLogEntity->setData($newSyncData);
+            $syncLogEntity->setFailed();
+            $syncLogEntity->setFinishTime(new DateTime());
+
+            $this->getSyncLogService()->update($syncLogEntity);
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+
+
+    /**
+     * @param \common_report_Report $report
+     * @return array
+     */
+    private function parseSyncData(\common_report_Report $report)
+    {
+        /** @var SyncLogDataParser $formatter */
+        $formatter = $this->getServiceLocator()->get(SyncLogDataParser::SERVICE_ID);
+
+        return $formatter->parseSyncData($report);
+    }
+
+    /**
+     * @return SyncLogServiceInterface
+     */
+    private function getSyncLogService()
+    {
+        return $this->getServiceLocator()->get(SyncLogServiceInterface::SERVICE_ID);
+    }
+}

--- a/model/listener/SyncStatusListener.php
+++ b/model/listener/SyncStatusListener.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+namespace oat\taoSync\model\listener;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoSync\model\client\SynchronisationClient;
+use oat\taoSync\model\event\SyncFinishedEvent;
+/**
+ * Class SyncStatusListener
+ * @package oat\taoSync\model\listener
+ */
+class SyncStatusListener extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/SyncStatusListener';
+    /**
+     * @param SyncFinishedEvent $event
+     */
+    public function sendSyncFinishedConfirmation(SyncFinishedEvent $event)
+    {
+        try {
+            /** @var SynchronisationClient $syncClient */
+            $syncClient = $this->getServiceLocator()->get(SynchronisationClient::SERVICE_ID);
+            $response = $syncClient->sendSyncFinishedConfirmation($event->getSyncParameters());
+            $this->logInfo(json_encode($response));
+        } catch (\Exception $e) {
+            $this->logError($e->getMessage());
+        }
+    }
+}

--- a/scripts/tool/SyncLog/RegisterCentralSyncLogListener.php
+++ b/scripts/tool/SyncLog/RegisterCentralSyncLogListener.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+namespace oat\taoSync\scripts\tool\synchronizationLog;
+use oat\oatbox\extension\InstallAction;
+use oat\taoSync\model\event\SyncFinishedEvent;
+use oat\taoSync\model\event\SyncRequestEvent;
+use oat\taoSync\model\event\SyncResponseEvent;
+use oat\taoSync\model\listener\CentralSyncLogListener;
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
+/**
+ * Class RegisterCentralSyncLogListener
+ */
+class RegisterCentralSyncLogListener extends InstallAction
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($params)
+    {
+        $this->registerEvent(SyncRequestEvent::class, [CentralSyncLogListener::SERVICE_ID, 'logSyncRequest']);
+        $this->registerEvent(SyncResponseEvent::class, [CentralSyncLogListener::SERVICE_ID, 'logSyncResponse']);
+        $this->registerEvent(SyncFinishedEvent::class, [CentralSyncLogListener::SERVICE_ID, 'logSyncFinished']);
+
+        if (!$this->getServiceManager()->has(SyncLogDataParser::SERVICE_ID)) {
+            $syncLogDataParser = new SyncLogDataParser([]);
+            $this->registerService(SyncLogDataParser::SERVICE_ID, $syncLogDataParser);
+        }
+
+        $syncLogListener = new CentralSyncLogListener([]);
+        $this->registerService(CentralSyncLogListener::SERVICE_ID, $syncLogListener);
+
+        return \common_report_Report::createSuccess('CentralSyncLogListener successfully registered.');
+    }
+}

--- a/scripts/tool/SyncLog/RegisterClientSyncLogListener.php
+++ b/scripts/tool/SyncLog/RegisterClientSyncLogListener.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\scripts\tool\synchronizationLog;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoSync\model\event\SyncFailedEvent;
+use oat\taoSync\model\event\SyncFinishedEvent;
+use oat\taoSync\model\event\SyncStartedEvent;
+use oat\taoSync\model\listener\ClientSyncLogListener;
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
+
+/**
+ * Class RegisterClientSyncLogListener
+ */
+class RegisterClientSyncLogListener extends InstallAction
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($params)
+    {
+        $this->registerEvent(SyncStartedEvent::class, [ClientSyncLogListener::SERVICE_ID, 'logSyncStarted']);
+        $this->registerEvent(SyncFinishedEvent::class, [ClientSyncLogListener::SERVICE_ID, 'logSyncFinished']);
+        $this->registerEvent(SyncFailedEvent::class, [ClientSyncLogListener::SERVICE_ID, 'logSyncFailed']);
+
+        if (!$this->getServiceManager()->has(SyncLogDataParser::SERVICE_ID)) {
+            $syncLogDataParser = new SyncLogDataParser([]);
+            $this->registerService(SyncLogDataParser::SERVICE_ID, $syncLogDataParser);
+        }
+
+        $syncLogListener = new ClientSyncLogListener([]);
+        $this->registerService(ClientSyncLogListener::SERVICE_ID, $syncLogListener);
+
+        return \common_report_Report::createSuccess('ClientSyncLogListener successfully registered.');
+    }
+}

--- a/scripts/tool/SyncLog/RegisterSyncStatusListener.php
+++ b/scripts/tool/SyncLog/RegisterSyncStatusListener.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\scripts\tool\synchronizationLog;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoSync\model\event\SyncFinishedEvent;
+use oat\taoSync\model\listener\SyncStatusListener;
+
+/**
+ * Class RegisterSyncStatusListener
+ * @package oat\taoSync\scripts\tool\synchronizationLog
+ */
+class RegisterSyncStatusListener extends InstallAction
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($params)
+    {
+        $this->registerEvent(SyncFinishedEvent::class, [SyncStatusListener::SERVICE_ID, 'sendSyncFinishedConfirmation']);
+
+        $syncStatusListener = new SyncStatusListener([]);
+        $this->getServiceManager()->register(SyncStatusListener::SERVICE_ID, $syncStatusListener);
+
+        return \common_report_Report::createSuccess('SyncStatusListener successfully registered.');
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -51,6 +51,8 @@ use oat\taoSync\model\synchronizer\custom\byOrganisationId\testcenter\TestCenter
 use oat\taoSync\model\synchronizer\delivery\DeliverySynchronizer;
 use oat\taoSync\model\synchronizer\user\proctor\ProctorSynchronizer;
 use oat\taoSync\model\SyncLog\Storage\RdsSyncLogStorage;
+use oat\taoSync\model\SyncLog\SyncLogService;
+use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
 use oat\taoSync\model\SyncService;
 use oat\taoSync\model\TestSession\SyncTestSessionService;
 use oat\taoSync\model\User\HandShakeClientService;
@@ -458,6 +460,16 @@ class Updater extends \common_ext_ExtensionUpdater
             $registerRdsSyncLogStorage->setServiceLocator($this->getServiceManager());
             $registerRdsSyncLogStorage->createTable($storage->getPersistence());
             $this->setVersion('3.2.0');
+        }
+
+        if ($this->isVersion('3.2.0')) {
+            $syncLogService = new SyncLogService([
+                SyncLogService::OPTION_STORAGE => RdsSyncLogStorage::SERVICE_ID
+            ]);
+            $syncLogService->setServiceLocator($this->getServiceManager());
+            $this->getServiceManager()->register(SyncLogServiceInterface::SERVICE_ID, $syncLogService);
+
+            $this->setVersion('3.3.0');
         }
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -51,6 +51,7 @@ use oat\taoSync\model\synchronizer\custom\byOrganisationId\testcenter\TestCenter
 use oat\taoSync\model\synchronizer\delivery\DeliverySynchronizer;
 use oat\taoSync\model\synchronizer\user\proctor\ProctorSynchronizer;
 use oat\taoSync\model\SyncLog\Storage\RdsSyncLogStorage;
+use oat\taoSync\model\SyncLog\SyncLogDataParser;
 use oat\taoSync\model\SyncLog\SyncLogService;
 use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
 use oat\taoSync\model\SyncService;
@@ -470,6 +471,14 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(SyncLogServiceInterface::SERVICE_ID, $syncLogService);
 
             $this->setVersion('3.3.0');
+        }
+
+        if ($this->isVersion('3.3.0')) {
+            $syncLogDataParser = new SyncLogDataParser([]);
+            $syncLogDataParser->setServiceLocator($this->getServiceManager());
+            $this->getServiceManager()->register(SyncLogDataParser::SERVICE_ID, $syncLogDataParser);
+
+            $this->setVersion('3.4.0');
         }
     }
 


### PR DESCRIPTION
Create synchronization events.
Create and register synchronization events listeners on client and central servers.

Depends on https://github.com/oat-sa/extension-tao-sync/pull/86