### PR TITLE
Update remote environment after successful handshake

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -590,6 +590,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.0.0');
         }
 
+        $this->skip('5.0.0', '5.0.1');
     }
 
     /**

--- a/test/User/HandShakeAuthAdapterTest.php
+++ b/test/User/HandShakeAuthAdapterTest.php
@@ -58,7 +58,7 @@ class HandShakeAuthAdapterTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HandShakeAuthAdapter $handShakeAdapter */
         $handShakeAdapter = $this->getMockBuilder(HandShakeAuthAdapter::class)->setMethods([
-            'callParentAuthenticate','handShakeWithServer'
+            'callParentAuthenticate', 'handShakeWithServer', 'logError'
         ])->getMockForAbstractClass();
 
         $handShakeAdapter
@@ -102,7 +102,7 @@ class HandShakeAuthAdapterTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HandShakeAuthAdapter $handShakeAdapter */
         $handShakeAdapter = $this->getMockBuilder(HandShakeAuthAdapter::class)->setMethods([
-            'callParentAuthenticate','handShakeWithServer'
+            'callParentAuthenticate', 'handShakeWithServer', 'logError'
         ])->getMockForAbstractClass();
 
         $handShakeAdapter

--- a/test/server/HandShakeServerResponseTest.php
+++ b/test/server/HandShakeServerResponseTest.php
@@ -22,6 +22,7 @@ namespace oat\taoSync\test\server;
 
 
 use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
 use oat\taoSync\model\formatter\SynchronizerFormatter;
 use oat\taoSync\model\server\HandShakeServerResponse;
 
@@ -30,6 +31,8 @@ class HandShakeServerResponseTest extends \PHPUnit_Framework_TestCase
     public function testAsArray()
     {
         $handShakeResponse = new HandShakeServerResponse($this->mockResource(), $this->mockResource(), $this->mockSynchronizer());
+        $handShakeResponse->setModel($this->mockModel());
+
         $this->assertEquals([
             'syncUser' => [
                 'property1' => 'value1'
@@ -81,6 +84,19 @@ class HandShakeServerResponseTest extends \PHPUnit_Framework_TestCase
             ->willReturn([
                 'property1' => 'value1'
             ]);
+
+        return $mock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockModel()
+    {
+        $mock = $this->getMockBuilder(Ontology::class)->disableOriginalConstructor()->getMock();
+        $mock
+            ->method('getProperty')
+            ->willReturn(new \core_kernel_classes_Property('PROP'));
 
         return $mock;
     }

--- a/test/server/HandShakeServerServiceTest.php
+++ b/test/server/HandShakeServerServiceTest.php
@@ -44,7 +44,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \oat\taoSync\model\server\InvalidRoleForSync
      */
-    public function testHandShakeNotASyncManger()
+    public function testHandShakeNotASyncManager()
     {
         $service = $this->getService();
         $response = $service->execute('123456');
@@ -59,7 +59,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     protected function getService($roles = [])
     {
         $service = $this->getMockBuilder(HandShakeServerService::class)
-            ->setMethods(['getUsersService', 'getGeneratorOauth'])->getMockForAbstractClass();
+            ->setMethods(['getUsersService', 'getGeneratorOauth', 'getProperty'])->getMockForAbstractClass();
 
         $service
             ->method('getUsersService')
@@ -69,11 +69,15 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getGeneratorOauth')
             ->willReturn($this->mockGenerator());
 
+        $service
+            ->method('getProperty')
+            ->willReturn($this->mockProperty());
+
         $serviceLocator = $this->getMockForAbstractClass(ServiceLocatorInterface::class);
         $serviceLocator
             ->method('get')
             ->will($this->onConsecutiveCalls(
-                $this->mockEventManger(),
+                $this->mockEventManager(),
                 $this->mockSyncService()
 
             ));
@@ -83,6 +87,9 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
         return $service;
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
     protected function mockGenerator()
     {
         $service = $this->getMockBuilder(GenerateOauthCredentials::class)
@@ -94,6 +101,17 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
         return $service;
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function mockProperty()
+    {
+        return $this->getMockBuilder(\core_kernel_classes_Property::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
     protected function mockSyncService()
     {
         $synchronizer = $this->getMockForAbstractClass(Synchronizer::class);
@@ -136,7 +154,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function mockEventManger()
+    protected function mockEventManager()
     {
         return
             $this->getMockBuilder(EventManager::class)


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7687

During the handshake, the client server deleted existing remote environment and created it again, this was fixed to update the existing remote environment instead.