### PR TITLE
Fix/organisation_id should not be necessarily only integer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '5.5.4',
+    'version' => '5.5.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/history/byOrganisationId/DataSyncHistoryByOrgIdService.php
+++ b/model/history/byOrganisationId/DataSyncHistoryByOrgIdService.php
@@ -131,9 +131,9 @@ class DataSyncHistoryByOrgIdService extends DataSyncHistoryService
             $orgId = $this->getResource(self::SYNCHRO_URI)
                 ->getOnePropertyValue($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
             if (is_null($orgId)) {
-                $this->organisationId = 0;
+                $this->organisationId = '';
             } else {
-                $this->organisationId = (int) $orgId->literal;
+                $this->organisationId = $orgId->literal;
             }
         }
         return $this->organisationId;

--- a/scripts/tool/SetupMultiSynchronisation.php
+++ b/scripts/tool/SetupMultiSynchronisation.php
@@ -54,7 +54,12 @@ class SetupMultiSynchronisation extends InstallAction
 
         try {
             $syncTable = $schema->getTable(DataSyncHistoryByOrgIdService::SYNC_TABLE);
-            $syncTable->addColumn(DataSyncHistoryByOrgIdService::SYNC_ORG_ID, 'integer', ['length' => 11]);
+            $syncTable->addColumn(
+                DataSyncHistoryByOrgIdService::SYNC_ORG_ID,
+                'string',
+                ['length' => 255, 'notnull' => true, 'default' => '']
+            );
+
             $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
             foreach ($queries as $query) {
                 $persistence->exec($query);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -677,14 +677,14 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('5.5.1', '5.5.4');
 
         if ($this->isVersion('5.5.4')) {
-            if ($this->getServiceManager()->has(DataSyncHistoryService::SERVICE_ID)) {
-                /** @var DataSyncHistoryService $service */
-                $service = $this->getServiceManager()->get(DataSyncHistoryService::SERVICE_ID);
+            if ($this->getServiceManager()->has(DataSyncHistoryByOrgIdService::SERVICE_ID)) {
+                /** @var DataSyncHistoryByOrgIdService $service */
+                $service = $this->getServiceManager()->get(DataSyncHistoryByOrgIdService::SERVICE_ID);
                 $persistence = $service->getPersistence();
                 $schemaManager = $persistence->getSchemaManager();
                 $fromSchema = $schemaManager->createSchema();
                 $toSchema = clone $fromSchema;
-                $table = $toSchema->getTable(DataSyncHistoryService::SYNC_TABLE);
+                $table = $toSchema->getTable(DataSyncHistoryByOrgIdService::SYNC_TABLE);
                 if ($table->hasColumn(DataSyncHistoryByOrgIdService::SYNC_ORG_ID)) {
                     $table->changeColumn(
                         DataSyncHistoryByOrgIdService::SYNC_ORG_ID,


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7927

If the Test Center field `Organisation Id` was not an integer, then entity synchronisation and test center proctoring was not working as expected. Logging in as a proctor would not show any test centers to select from.