### PR TITLE
Supported vm versions api returns empty value on PHP 5.6

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '5.6.0',
+    'version' => '5.6.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/VirtualMachine/SupportedVmService.php
+++ b/model/VirtualMachine/SupportedVmService.php
@@ -59,6 +59,13 @@ class SupportedVmService extends ConfigurableService
         $property = $this->getProperty(self::PROPERTY_VM_VERSION);
         $supportedVersions = $class->getInstancesPropertyValues($property);
 
-        return array_column($supportedVersions, 'literal');
+        $result = [];
+        foreach ($supportedVersions as $version) {
+            if ($version instanceof \core_kernel_classes_Literal) {
+                $result[] = $version->literal;
+            }
+        }
+
+        return $result;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -718,6 +718,8 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('5.6.0');
         }
+
+        $this->skip('5.6.0', '5.6.1');
     }
 
     /**


### PR DESCRIPTION
`array_column` function doesn't work as expected with object on PHP 5.6. Because of that `/taoSync/api/supportedVm` API always returns empty list.

Ticket - https://oat-sa.atlassian.net/browse/TAO-7782