### PR TITLE
Feature/tao 7188/add box id on client sync history dashboard

### DIFF
--- a/config/default/VmIdentifierService.conf.php
+++ b/config/default/VmIdentifierService.conf.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+use oat\taoSync\model\VirtualMachine\VmIdentifierService;
+
+return new VmIdentifierService([]);

--- a/controller/SynchronizationHistory.php
+++ b/controller/SynchronizationHistory.php
@@ -23,6 +23,7 @@ use oat\oatbox\session\SessionService;
 use oat\tao\model\datatable\implementation\DatatableRequest;
 use oat\taoSync\model\SynchronizationHistory\HistoryPayloadFormatterInterface;
 use oat\taoSync\model\SynchronizationHistory\SynchronizationHistoryServiceInterface;
+use oat\taoSync\model\VirtualMachine\VmIdentifierService;
 use tao_actions_CommonModule;
 
 /**
@@ -39,6 +40,10 @@ class SynchronizationHistory extends tao_actions_CommonModule
         $this->setData('config', [
             'dataModel' => $this->getServiceLocator()->get(HistoryPayloadFormatterInterface::SERVICE_ID)->getDataModel()
         ]);
+
+        if ($this->getServiceLocator()->has(VmIdentifierService::SERVICE_ID)) {
+            $this->setData('boxId', $this->getServiceLocator()->get(VmIdentifierService::SERVICE_ID)->getBoxId());
+        }
 
         $this->setView('sync/history.tpl', 'taoSync');
     }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '6.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/VirtualMachine/VmIdentifierService.php
+++ b/model/VirtualMachine/VmIdentifierService.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\model\VirtualMachine;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoPublishing\model\publishing\PublishingService;
+use oat\taoSync\scripts\tool\synchronisation\SynchronizeData;
+
+class VmIdentifierService extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/VmIdentifierService';
+
+    /**
+     * Return Virtual Machine identifier: BoxId
+     *
+     * @return string|null
+     */
+    public function getBoxId()
+    {
+        try {
+            return $this->getServiceLocator()->get(PublishingService::SERVICE_ID)->getBoxIdByAction(SynchronizeData::class);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -719,7 +719,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.6.0');
         }
 
-        $this->skip('5.6.0', '6.1.0');
+        $this->skip('5.6.0', '6.2.0');
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -78,6 +78,7 @@ use oat\taoSync\model\testCenter\TestCenterService;
 use oat\taoSync\model\TestSession\SyncTestSessionService;
 use oat\taoSync\model\User\HandShakeClientService;
 use oat\taoSync\model\Validator\SyncParamsValidator;
+use oat\taoSync\model\VirtualMachine\VmIdentifierService;
 use oat\taoSync\model\VirtualMachine\VmVersionChecker;
 use oat\taoSync\scripts\tool\synchronisation\SynchronizeData;
 use oat\taoSync\model\ui\FormFieldsService;
@@ -719,7 +720,14 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.6.0');
         }
 
-        $this->skip('5.6.0', '6.2.0');
+        $this->skip('5.6.0', '6.1.0');
+
+        if ($this->isVersion('6.1.0')) {
+            $vmIdentifierService = new VmIdentifierService([]);
+            $this->getServiceManager()->register(VmIdentifierService::SERVICE_ID, $vmIdentifierService);
+
+            $this->setVersion('6.2.0');
+        }
     }
 
     /**

--- a/test/unit/VirtualMachine/VmIdentifierServiceTest.php
+++ b/test/unit/VirtualMachine/VmIdentifierServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\test\unit\VirtualMachine;
+
+use oat\generis\test\TestCase;
+use oat\taoPublishing\model\publishing\PublishingService;
+use oat\taoSync\model\VirtualMachine\VmIdentifierService;
+
+class VmIdentifierServiceTest extends TestCase
+{
+    /**
+     * @var VmIdentifierService
+     */
+    private $object;
+
+    /**
+     * @var PublishingService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $publishingServiceMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->publishingServiceMock = $this->createMock(PublishingService::class);
+        $slMock  = $this->getServiceLocatorMock([
+            PublishingService::SERVICE_ID => $this->publishingServiceMock
+        ]);
+
+        $this->object = new VmIdentifierService([]);
+        $this->object->setServiceLocator($slMock);
+    }
+
+    public function testGetBoxIdFails()
+    {
+        $this->publishingServiceMock
+            ->method('getBoxIdByAction')
+            ->willThrowException(new \common_Exception('Dummy message'));
+
+        $boxId = $this->object->getBoxId();
+        $this->assertNull($boxId, 'Returned Box ID value must be as expected in case when Exception was thrown.');
+    }
+
+    public function testGetBoxId()
+    {
+        $expectedBoxId = 'DUMMY_BOX_ID';
+
+        $this->publishingServiceMock
+            ->method('getBoxIdByAction')
+            ->willReturn($expectedBoxId);
+
+        $boxId = $this->object->getBoxId();
+        $this->assertEquals($expectedBoxId, $boxId, 'Returned Box ID value must be as expected.');
+    }
+}

--- a/views/templates/sync/history.tpl
+++ b/views/templates/sync/history.tpl
@@ -8,6 +8,9 @@ use oat\tao\helpers\Template;
         <header>
             <h2><?= __('Synchronization History') ?></h2>
         </header>
+        <?php if(!empty($boxId)): ?>
+            <p><?= __('Box ID') ?>: <?= $boxId ?></p>
+        <?php endif; ?>
     </div>
     <div class="grid-row">
         <div class="col-12">


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-7188

The goal is to add VM Box ID on synchronization history page, available for a user with 'Sync Manager' role. I should be present only on client instance.
To test:
- login as a user with 'Sync Manager' role
- go Synchronization History page
In table header under page title you should see '**Box ID: XXXXXX**' 