### PR TITLE
Fix/tao 7090/sync in async mode

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.4.0',
+    'version' => '6.4.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/history/byOrganisationId/DataSyncHistoryByOrgIdService.php
+++ b/model/history/byOrganisationId/DataSyncHistoryByOrgIdService.php
@@ -38,8 +38,6 @@ class DataSyncHistoryByOrgIdService extends DataSyncHistoryService
 
     const SYNC_ORG_ID = 'organisation_id';
 
-    protected $organisationId;
-
     /**
      * Get the entities not updated by the current synchro (scoped to organisation id).
      * It means that there are not in remote server anymore
@@ -126,16 +124,14 @@ class DataSyncHistoryByOrgIdService extends DataSyncHistoryService
      */
     protected function getCurrentOrganisationId()
     {
-        if (!$this->organisationId) {
-            $orgId = $this->getResource(self::SYNCHRO_URI)
-                ->getOnePropertyValue($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
-            if (is_null($orgId)) {
-                $this->organisationId = '';
-            } else {
-                $this->organisationId = $orgId->literal;
-            }
+        $orgId = $this->getResource(self::SYNCHRO_URI)
+            ->getOnePropertyValue($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
+
+        if (is_null($orgId)) {
+            return '';
         }
-        return $this->organisationId;
+
+        return $orgId->literal;
     }
 
     /**
@@ -238,7 +234,6 @@ class DataSyncHistoryByOrgIdService extends DataSyncHistoryService
         }
     }
 
-
     /**
      * @param string $entity
      * @return mixed
@@ -259,5 +254,4 @@ class DataSyncHistoryByOrgIdService extends DataSyncHistoryService
 
         return $results[self::SYNC_ORG_ID];
     }
-
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -737,6 +737,8 @@ class Updater extends \common_ext_ExtensionUpdater
             );
             $this->setVersion('6.4.0');
         }
+
+        $this->skip('6.4.0', '6.4.1');
     }
 
     /**


### PR DESCRIPTION
Synchronization in background task work incorrect.
https://oat-sa.atlassian.net/browse/TAO-7090
https://oat-sa.atlassian.net/browse/TAO-7901
Steps to reproduce:
Precondition: Created two Test Centers with assigned individually Test Center Admins, Sync Managers, proctors.

Steps to reproduce:
1. Perform a synchronization for first Test Center by related Sync Manager.
2. Log in as Test Center Admin and check that TC Admin is able to see Test Center and authorize assigned Proctor.
3. Perform a synchronization for second Test Center by related Sync Manager.
4. Log in as TC Admin.
Actual result: The current TC Admin is not able to see Test center and related proctor to assign ).
Expected result: TC Admin is able to see Test Center and authorize assigned Proctor.

To reproduce synchronization should run in the background process: in this case 
DataSyncHistoryByOrgIdService cache protected property and  do not renew it during next 
synchronization task
