### PR TITLE
Feature/tao 8664/export results

### DIFF
--- a/config/default/SyncResultDataFormatter.conf.php
+++ b/config/default/SyncResultDataFormatter.conf.php
@@ -1,0 +1,5 @@
+<?php
+
+use oat\taoSync\model\SyncResultDataFormatter;
+
+return new SyncResultDataFormatter();

--- a/config/default/SyncResultDataProvider.conf.php
+++ b/config/default/SyncResultDataProvider.conf.php
@@ -1,0 +1,10 @@
+<?php
+
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoSync\model\Result\SyncResultDataProvider;
+
+return new SyncResultDataProvider(array(
+    SyncResultDataProvider::OPTION_STATUS_EXECUTIONS_TO_SYNC => [
+        DeliveryExecution::STATE_FINISHED,
+    ],
+));

--- a/config/default/resultService.conf.php
+++ b/config/default/resultService.conf.php
@@ -1,12 +1,8 @@
 <?php
 
-use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoSync\model\ResultService;
 
 return new ResultService(array(
     ResultService::OPTION_CHUNK_SIZE => ResultService::DEFAULT_CHUNK_SIZE,
     ResultService::OPTION_DELETE_AFTER_SEND => false,
-    ResultService::OPTION_STATUS_EXECUTIONS_TO_SYNC => [
-        DeliveryExecution::STATE_FINISHIED,
-    ],
 ));

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.5.4.1',
+    'version' => '6.6.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.5.4',
+    'version' => '6.5.4.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/Result/SyncResultDataFormatter.php
+++ b/model/Result/SyncResultDataFormatter.php
@@ -33,7 +33,7 @@ class SyncResultDataFormatter extends ConfigurableService
 
     /**
      * @param DeliveryExecution $deliveryExecution
-     * @return array
+     * @return null|array
      * @throws \common_exception_NotFound
      * @throws \core_kernel_persistence_Exception
      */
@@ -45,7 +45,7 @@ class SyncResultDataFormatter extends ConfigurableService
         // Do no send delivery execution with no variables (deleted)
         $variables = $this->getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId);
         if (empty($variables)) {
-            null;
+            return null;
         }
 
         return [

--- a/model/Result/SyncResultDataFormatter.php
+++ b/model/Result/SyncResultDataFormatter.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoSync\model\Result;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDeliveryRdf\helper\DetectTestAndItemIdentifiersHelper;
+use oat\taoResultServer\models\classes\ResultManagement;
+use oat\taoResultServer\models\classes\ResultServerService;
+
+class SyncResultDataFormatter extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/SyncResultsDataFormatter';
+
+    /**
+     * @param DeliveryExecution $deliveryExecution
+     * @return array
+     * @throws \common_exception_NotFound
+     * @throws \core_kernel_persistence_Exception
+     */
+    public function format($deliveryExecution)
+    {
+        $deliveryExecutionId = $deliveryExecution->getIdentifier();
+        $deliveryId = $deliveryExecution->getDelivery()->getUri();
+
+        // Do no send delivery execution with no variables (deleted)
+        $variables = $this->getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId);
+        if (empty($variables)) {
+            null;
+        }
+
+        return [
+            'deliveryId' => $deliveryId,
+            'deliveryExecutionId' => $deliveryExecutionId,
+            'details' => $this->getDeliveryExecutionDetails($deliveryExecutionId),
+            'variables' => $variables,
+        ];
+    }
+
+    /**
+     * Get variables of a delivery execution
+     *
+     * @param $deliveryId
+     * @param $deliveryExecutionId
+     * @return array
+     * @throws \core_kernel_persistence_Exception
+     */
+    protected function getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId)
+    {
+        $variables = $this->getResultStorage($deliveryId)->getDeliveryVariables($deliveryExecutionId);
+        $deliveryExecutionVariables = [];
+        foreach ($variables as $variable) {
+            $variable = (array) $variable[0];
+            list($testIdentifier,$itemIdentifier) = $this->detectTestAndItemIdentifiers($deliveryId, $variable);
+            $deliveryExecutionVariables[] = [
+                'type' => $variable['class'],
+                'callIdTest' => isset($variable['callIdTest'])? $variable['callIdTest'] : null,
+                'callIdItem' => isset($variable['callIdItem']) ? $variable['callIdItem'] : null,
+                'test' => $testIdentifier,
+                'item' => $itemIdentifier,
+                'data' => $variable['variable'],
+            ];
+        }
+
+        return $deliveryExecutionVariables;
+    }
+
+    /**
+     * @param $deliveryId
+     * @param $variable
+     * @return array
+     * @throws \core_kernel_persistence_Exception
+     */
+    private function detectTestAndItemIdentifiers($deliveryId, $variable)
+    {
+        $test = isset($variable['test']) ? $variable['test'] : null;
+        $item = isset($variable['item']) ? $variable['item'] : null;
+        return (new DetectTestAndItemIdentifiersHelper())->detect($deliveryId, $test, $item);
+    }
+
+    /**
+     * Get details of a delivery execution
+     *
+     * @param $deliveryExecutionId
+     * @return array
+     */
+    private function getDeliveryExecutionDetails($deliveryExecutionId)
+    {
+        /** @var DeliveryExecution $deliveryExecution */
+        $deliveryExecution = $this->getDeliveryExecutionService()->getDeliveryExecution($deliveryExecutionId);
+        try {
+            return [
+                'identifier' => $deliveryExecution->getIdentifier(),
+                'label' => $deliveryExecution->getLabel(),
+                'test-taker' => $deliveryExecution->getUserIdentifier(),
+                'starttime' => $deliveryExecution->getStartTime(),
+                'finishtime' => $deliveryExecution->getFinishTime(),
+                'state' => $deliveryExecution->getState()->getUri(),
+            ];
+        } catch (\common_exception_NotFound $e) {
+            return [];
+        }
+    }
+
+    /**
+     * @return ServiceProxy
+     */
+    private function getDeliveryExecutionService()
+    {
+        return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
+    }
+
+    /**
+     * Fetch the delivery result server from delivery
+     *
+     * @param $deliveryId
+     * @return ResultManagement | \taoResultServer_models_classes_WritableResultStorage
+     */
+    private function getResultStorage($deliveryId)
+    {
+        return $this->getServiceLocator()->get(ResultServerService::SERVICE_ID)->getResultStorage($deliveryId);
+    }
+}

--- a/model/Result/SyncResultDataProvider.php
+++ b/model/Result/SyncResultDataProvider.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoSync\model\Result;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\Monitoring;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoResultServer\models\classes\ResultManagement;
+use oat\taoResultServer\models\classes\ResultServerService;
+use oat\taoSync\model\history\ResultSyncHistoryService;
+
+class SyncResultDataProvider extends ConfigurableService
+{
+    const SERVICE_ID = 'taoSync/SyncResultDataProvider';
+
+    const OPTION_STATUS_EXECUTIONS_TO_SYNC = 'statusExecutionsToSync';
+
+    /**
+     * @param $chunkSize
+     * @return \Generator
+     * @throws \common_exception_Error
+     * @throws \common_exception_NoImplementation
+     * @throws \common_exception_NotFound
+     */
+    public function getDeliveryExecutions($chunkSize)
+    {
+        $deliveryExecutions = [];
+        $counter = 0;
+
+        /** @var \core_kernel_classes_Resource $delivery */
+        foreach ($this->getDeliveryAssemblyService()->getAllAssemblies() as $delivery) {
+            /** @var DeliveryExecution $deliveryExecution */
+            foreach ($this->getDeliveryExecutionByDelivery($delivery) as $deliveryExecution) {
+                $deliveryExecutionId = $deliveryExecution->getIdentifier();
+                $statesToSync = $this->getExecutionsStatesAvailableForSync();
+                $currentState = $deliveryExecution->getState()->getUri();
+
+                // Skip non white listed states of delivery executions.
+                if (!in_array($currentState, $statesToSync)){
+                    continue;
+                }
+
+                // Do not resend delivery execution already exported
+                if ($this->getResultSyncHistory()->isAlreadyExported($deliveryExecutionId)) {
+                    continue;
+                }
+
+                $deliveryExecutions[] = $deliveryExecution;
+
+                $counter++;
+
+                if ($counter % $chunkSize === 0) {
+                    yield $deliveryExecutions;
+                    $deliveryExecutions = [];
+                }
+            }
+        }
+
+        yield $deliveryExecutions;
+    }
+
+    /**
+     * @return DeliveryAssemblyService
+     */
+    protected function getDeliveryAssemblyService()
+    {
+        return DeliveryAssemblyService::singleton();
+    }
+
+    /**
+     * @return ServiceProxy
+     */
+    protected function getDeliveryExecutionService()
+    {
+        return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
+    }
+
+    /**
+     * Fetch the delivery result server from delivery
+     *
+     * @param $deliveryId
+     * @return ResultManagement | \taoResultServer_models_classes_WritableResultStorage
+     */
+    protected function getResultStorage($deliveryId)
+    {
+        return $this->getServiceLocator()->get(ResultServerService::SERVICE_ID)->getResultStorage($deliveryId);
+    }
+
+    /**
+     * @return ResultSyncHistoryService
+     */
+    protected function getResultSyncHistory()
+    {
+        return $this->getServiceLocator()->get(ResultSyncHistoryService::SERVICE_ID);
+    }
+
+    /**
+     * Get delivery executions by delivery
+     *
+     * @param \core_kernel_classes_Resource $delivery
+     * @return array|DeliveryExecution[]
+     * @throws \common_exception_Error
+     * @throws \common_exception_NoImplementation
+     */
+    protected function getDeliveryExecutionByDelivery(\core_kernel_classes_Resource $delivery)
+    {
+        $serviceProxy = $this->getDeliveryExecutionService();
+        if (!$serviceProxy instanceof Monitoring) {
+            $resultStorage = $this->getResultStorage($delivery->getUri());
+            $results = $resultStorage->getResultByDelivery([$delivery->getUri()]);
+            $executions = [];
+            foreach ($results as $result) {
+                $executions[] = $serviceProxy->getDeliveryExecution($result['deliveryResultIdentifier']);
+            }
+        } else{
+            $executions = $serviceProxy->getExecutionsByDelivery($delivery);
+        }
+        return $executions;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExecutionsStatesAvailableForSync()
+    {
+        $statuses = $this->getOption(static::OPTION_STATUS_EXECUTIONS_TO_SYNC);
+        if ($statuses == null){
+            return [DeliveryExecution::STATE_FINISHED];
+        }
+
+        return $statuses;
+    }
+}

--- a/model/Result/SyncResultDataProvider.php
+++ b/model/Result/SyncResultDataProvider.php
@@ -49,10 +49,10 @@ class SyncResultDataProvider extends ConfigurableService
 
         /** @var \core_kernel_classes_Resource $delivery */
         foreach ($this->getDeliveryAssemblyService()->getAllAssemblies() as $delivery) {
+            $statesToSync = $this->getExecutionsStatesAvailableForSync();
             /** @var DeliveryExecution $deliveryExecution */
             foreach ($this->getDeliveryExecutionByDelivery($delivery) as $deliveryExecution) {
                 $deliveryExecutionId = $deliveryExecution->getIdentifier();
-                $statesToSync = $this->getExecutionsStatesAvailableForSync();
                 $currentState = $deliveryExecution->getState()->getUri();
 
                 // Skip non white listed states of delivery executions.

--- a/model/ResultService.php
+++ b/model/ResultService.php
@@ -25,16 +25,15 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
-use oat\taoDelivery\model\execution\Monitoring;
 use oat\taoDelivery\model\execution\ServiceProxy;
-use oat\taoDeliveryRdf\helper\DetectTestAndItemIdentifiersHelper;
-use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoResultServer\models\classes\ResultManagement;
 use oat\taoResultServer\models\classes\ResultServerService;
 use oat\taoSync\model\client\SynchronisationClient;
 use oat\taoSync\model\event\SyncResponseEvent;
 use oat\taoSync\model\history\ResultSyncHistoryService;
 use oat\taoSync\model\Mapper\OfflineResultToOnlineResultMapper;
+use oat\taoSync\model\Result\SyncResultDataFormatter;
+use oat\taoSync\model\Result\SyncResultDataProvider;
 use oat\taoSync\model\SyncLog\SyncLogDataHelper;
 use Psr\Log\LogLevel;
 
@@ -50,7 +49,6 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
 
     const OPTION_CHUNK_SIZE = 'chunkSize';
     const OPTION_DELETE_AFTER_SEND = 'deleteAfterSend';
-    const OPTION_STATUS_EXECUTIONS_TO_SYNC = 'statusExecutionsToSync';
 
     const DEFAULT_CHUNK_SIZE = 10;
 
@@ -79,60 +77,37 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
         $results = [];
         $counter = 0;
 
-        /** @var \core_kernel_classes_Resource $delivery */
-        foreach ($this->getDeliveryAssemblyService()->getAllAssemblies() as $delivery) {
-            $deliveryId = $delivery->getUri();
-            /** @var DeliveryExecution $deliveryExecution */
-            foreach ($this->getDeliveryExecutionByDelivery($delivery) as $deliveryExecution) {
-                $deliveryExecutionId = $deliveryExecution->getIdentifier();
-                $statesToSync        = $this->getExecutionsStatesAvailableForSync();
-                $currentState        = $deliveryExecution->getState()->getUri();
-                // Skip non white listed states of delivery executions.
-                if (!in_array($currentState, $statesToSync)){
-                    continue;
-                }
-
-                // Do not resend delivery execution already exported
-                if ($this->getResultSyncHistory()->isAlreadyExported($deliveryExecutionId)) {
-                    continue;
-                }
-
-                // Do no send delivery execution with no variables (deleted)
-                $variables = $this->getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId);
-                if (empty($variables)) {
-                    continue;
-                }
-
-                $this->report('Formatting delivery execution ' . $deliveryExecution->getIdentifier() . '...');
-                $results[$deliveryExecutionId] = [
-                    'deliveryId' => $deliveryId,
-                    'deliveryExecutionId' => $deliveryExecutionId,
-                    'details' => $this->getDeliveryExecutionDetails($deliveryExecutionId),
-                    'variables' => $variables,
-                ];
-
-                $this->report(count($variables) . ' delivery execution variables found.');
-
-                $counter++;
-
-                if ($counter % $this->getChunkSize() === 0) {
-                    $this->report($counter . ' delivery executions to send to remote server. Sending...', LogLevel::INFO);
-                    $this->sendResults($results, $params);
-                    $results = [];
-                }
+        /** @var SyncResultDataProvider $dataProvider */
+        $dataProvider = $this->getServiceLocator()->get(SyncResultDataProvider::SERVICE_ID);
+        foreach ($dataProvider->getDeliveryExecutions($this->getChunkSize()) as $chunkOfDeliveryExecutions) {
+            if (empty($chunkOfDeliveryExecutions)) {
+                continue;
             }
+            /** @var DeliveryExecution $deliveryExecution */
+            foreach ($chunkOfDeliveryExecutions as $deliveryExecution) {
+                $deliveryExecutionId = $deliveryExecution->getIdentifier();
+                $this->report('Formatting delivery execution ' . $deliveryExecutionId . '...');
+
+                $formattedDeliveryExecution = $this->getSyncResultsFormatterService()->format($deliveryExecution);
+                if (empty($formattedDeliveryExecution)) {
+                    continue;
+                }
+                $this->report(count($formattedDeliveryExecution['variables']) . ' delivery execution variables found.');
+
+                $results[$deliveryExecutionId] = $formattedDeliveryExecution;
+                $counter++;
+            }
+
+            $this->report($counter . ' delivery executions to send to remote server. Sending...', LogLevel::INFO);
+            $this->sendResults($results, $params);
+            $results = [];
         }
 
         if ($counter === 0) {
             $this->report('No result to synchronize', LogLevel::INFO);
         }
 
-        if (!empty($results)) {
-            $this->sendResults($results, $params);
-        }
-
         return $this->report;
-
     }
 
     /**
@@ -283,30 +258,6 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
     }
 
     /**
-     * Get details of a delivery execution
-     *
-     * @param $deliveryExecutionId
-     * @return array
-     */
-    protected function getDeliveryExecutionDetails($deliveryExecutionId)
-    {
-        /** @var DeliveryExecution $deliveryExecution */
-        $deliveryExecution = $this->getDeliveryExecutionService()->getDeliveryExecution($deliveryExecutionId);
-        try {
-            return [
-                'identifier' => $deliveryExecution->getIdentifier(),
-                'label' => $deliveryExecution->getLabel(),
-                'test-taker' => $deliveryExecution->getUserIdentifier(),
-                'starttime' => $deliveryExecution->getStartTime(),
-                'finishtime' => $deliveryExecution->getFinishTime(),
-                'state' => $deliveryExecution->getState()->getUri(),
-            ];
-        } catch (\common_exception_NotFound $e) {
-            return [];
-        }
-    }
-
-    /**
      * Check if $result has the correct keys to be processed
      *
      * @param array $data
@@ -327,47 +278,6 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
         if (!empty(array_diff_key(array_flip($details), $data['details']))) {
             throw new \InvalidArgumentException('Result details are not correctly formatted, should contains : ' . implode(', ', $details));
         }
-    }
-
-    /**
-     * Get variables of a delivery execution
-     *
-     * @param $deliveryId
-     * @param $deliveryExecutionId
-     * @return array
-     * @throws \core_kernel_persistence_Exception
-     */
-    protected function getDeliveryExecutionVariables($deliveryId, $deliveryExecutionId)
-    {
-        $variables = $this->getResultStorage($deliveryId)->getDeliveryVariables($deliveryExecutionId);
-        $deliveryExecutionVariables = [];
-        foreach ($variables as $variable) {
-            $variable = (array) $variable[0];
-            list($testIdentifier,$itemIdentifier) = $this->detectTestAndItemIdentifiers($deliveryId, $variable);
-            $deliveryExecutionVariables[] = [
-                'type' => $variable['class'],
-                'callIdTest' => isset($variable['callIdTest'])? $variable['callIdTest'] : null,
-                'callIdItem' => isset($variable['callIdItem']) ? $variable['callIdItem'] : null,
-                'test' => $testIdentifier,
-                'item' => $itemIdentifier,
-                'data' => $variable['variable'],
-            ];
-        }
-
-        return $deliveryExecutionVariables;
-    }
-
-    /**
-     * @param $deliveryId
-     * @param $variable
-     * @return array
-     * @throws \core_kernel_persistence_Exception
-     */
-    protected function detectTestAndItemIdentifiers($deliveryId, $variable)
-    {
-        $test = isset($variable['test']) ? $variable['test'] : null;
-        $item = isset($variable['item']) ? $variable['item'] : null;
-        return (new DetectTestAndItemIdentifiersHelper())->detect($deliveryId, $test, $item);
     }
 
     /**
@@ -433,28 +343,6 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
         }
 
         $this->report(count($successfullyExportedResults) . ' deleted.', LogLevel::INFO);
-    }
-
-    /**
-     * Get delivery executions by delivery
-     *
-     * @param \core_kernel_classes_Resource $delivery
-     * @return array|DeliveryExecution[]
-     */
-    protected function getDeliveryExecutionByDelivery(\core_kernel_classes_Resource $delivery)
-    {
-        $serviceProxy = $this->getDeliveryExecutionService();
-        if (!$serviceProxy instanceof Monitoring) {
-            $resultStorage = $this->getResultStorage($delivery->getUri());
-            $results = $resultStorage->getResultByDelivery([$delivery->getUri()]);
-            $executions = [];
-            foreach ($results as $result) {
-                $executions[] = $serviceProxy->getDeliveryExecution($result['deliveryResultIdentifier']);
-            }
-        } else{
-            $executions = $serviceProxy->getExecutionsByDelivery($delivery);
-        }
-        return $executions;
     }
 
     /**
@@ -557,6 +445,14 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
     }
 
     /**
+     * @return SyncResultDataFormatter
+     */
+    protected function getSyncResultsFormatterService()
+    {
+        return $this->getServiceLocator()->get(SyncResultDataFormatter::SERVICE_ID);
+    }
+
+    /**
      * @return SynchronisationClient
      */
     protected function getSyncClient()
@@ -570,27 +466,6 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
     protected function getDeliveryExecutionService()
     {
         return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
-    }
-
-    /**
-     * @return DeliveryAssemblyService
-     */
-    protected function getDeliveryAssemblyService()
-    {
-        return DeliveryAssemblyService::singleton();
-    }
-
-    /**
-     * @return array
-     */
-    protected function getExecutionsStatesAvailableForSync()
-    {
-        $statuses = $this->getOption(static::OPTION_STATUS_EXECUTIONS_TO_SYNC);
-        if ($statuses == null){
-            return [DeliveryExecution::STATE_FINISHIED];
-        }
-
-        return $statuses;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -57,6 +57,8 @@ use oat\taoSync\model\OfflineMachineChecksService;
 use oat\taoSync\model\Parser\DeliveryExecutionContextParser;
 use oat\taoSync\model\ResultService;
 use oat\taoSync\model\server\HandShakeServerService;
+use oat\taoSync\model\Result\SyncResultDataProvider;
+use oat\taoSync\model\Result\SyncResultDataFormatter;
 use oat\taoSync\model\testCenter\SyncManagerTreeService;
 use oat\taoSync\model\VirtualMachine\SupportedVmService;
 use oat\taoSync\model\SynchronizationHistory\HistoryPayloadFormatter;
@@ -738,6 +740,25 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.4.0');
         }
         $this->skip('6.4.0', '6.5.4');
+
+        if ($this->isVersion('6.5.4')) {
+
+            $resultService = $this->getServiceManager()->get(ResultService::SERVICE_ID);
+            $currentOptionValue = $resultService->getOption(SyncResultDataProvider::OPTION_STATUS_EXECUTIONS_TO_SYNC);
+            $resultService->setOptions([
+                ResultService::OPTION_CHUNK_SIZE => $resultService->getOption(ResultService::OPTION_CHUNK_SIZE),
+                ResultService::OPTION_DELETE_AFTER_SEND => $resultService->getOption(ResultService::OPTION_DELETE_AFTER_SEND),
+            ]);
+            $this->getServiceManager()->register(ResultService::SERVICE_ID, $resultService);
+
+            $syncResultDataProvider = new SyncResultDataProvider([SyncResultDataProvider::OPTION_STATUS_EXECUTIONS_TO_SYNC => $currentOptionValue]);
+            $this->getServiceManager()->register(SyncResultDataProvider::SERVICE_ID, $syncResultDataProvider);
+
+            $syncResultsDataFormatter = new SyncResultDataFormatter([]);
+            $this->getServiceManager()->register(SyncResultDataFormatter::SERVICE_ID, $syncResultsDataFormatter);
+
+            $this->setVersion('6.5.4.1');
+        }
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -757,7 +757,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $syncResultsDataFormatter = new SyncResultDataFormatter([]);
             $this->getServiceManager()->register(SyncResultDataFormatter::SERVICE_ID, $syncResultsDataFormatter);
 
-            $this->setVersion('6.5.4.1');
+            $this->setVersion('6.6.0');
         }
     }
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8664

This refactoring enables the reuse of delivery execution selection for result export. Current result synchronization should work the same.

Dependent PR:  https://github.com/oat-sa/extension-tao-encryption/pull/72
