### PR TITLE
Fix/empty results sync

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.6.1',
+    'version' => '6.6.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/ResultService.php
+++ b/model/ResultService.php
@@ -122,6 +122,10 @@ class ResultService extends ConfigurableService implements SyncResultServiceInte
      */
     public function sendResults($results, array $params = [])
     {
+        if (empty($results)) {
+            $this->report('No results to be synchronized.', LogLevel::INFO);
+            return;
+        }
         $importAcknowledgment = $this->getSyncClient()->sendResults($results, $params);
         if (empty($importAcknowledgment)) {
             throw new \common_Exception('Error during result synchronisation. No acknowledgment was provided by remote server.');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -769,6 +769,8 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('6.6.1');
         }
+
+        $this->skip('6.6.1', '6.6.2');
     }
 
     /**


### PR DESCRIPTION
In case if there is no results to be synchronized process fails with error message: 
`An error has occurred: Error during result synchronisation. No acknowledgment was provided by remote server.`

to reproduce try to run synchronization process on the VM without any finished execution.