### PR TITLE
TAO-8665. Import server `enable` option

### DIFF
--- a/config/default/ExportService.conf.php
+++ b/config/default/ExportService.conf.php
@@ -25,5 +25,6 @@ return new ExportService(array(
         ResultsExporter::TYPE => new ResultsExporter([
             ResultsExporter::OPTION_BATCH_SIZE => ResultsExporter::DEFAULT_BATCH_SIZE
         ])
-    ]
+    ],
+    ExportService::OPTION_IS_ENABLED => false
 ));

--- a/config/default/ImportService.conf.php
+++ b/config/default/ImportService.conf.php
@@ -13,5 +13,6 @@ return new ImportService([
             EntityImporterInterface::OPTION_CLASS => ResultsImporter::class,
             EntityImporterInterface::OPTION_PARAMETERS => []
         ]
-    ]
+    ],
+    ImportService::OPTION_IS_ENABLED => false
 ]);

--- a/controller/Synchronizer.php
+++ b/controller/Synchronizer.php
@@ -32,6 +32,7 @@ use oat\taoSync\model\Exception\NotSupportedVmVersionException;
 use oat\taoSync\model\Execution\DeliveryExecutionStatusManager;
 use oat\taoSync\model\Export\ExportService;
 use oat\taoSync\model\history\DataSyncHistoryService;
+use oat\taoSync\model\import\ImportService;
 use oat\taoSync\model\OfflineMachineChecksService;
 use oat\taoSync\model\Parser\DeliveryExecutionContextParser;
 use oat\taoSync\model\SynchronizeAllTaskBuilderService;
@@ -71,7 +72,9 @@ class Synchronizer extends \tao_actions_CommonModule
         $this->setData('dashboard-url', $dashboardUrl);
 
         $exportService = $this->getServiceLocator()->get(ExportService::SERVICE_ID);
+        $importService = $this->getServiceLocator()->get(ImportService::SERVICE_ID);
         $this->setData('isExportEnabled', $exportService->getOption(ExportService::OPTION_IS_ENABLED));
+        $this->setData('isImportEnabled', $importService->getOption(ImportService::OPTION_IS_ENABLED));
 
         $this->setView('sync/index.tpl', self::EXTENSION_ID);
     }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.11.0',
+    'version' => '6.12.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/import/ImportService.php
+++ b/model/import/ImportService.php
@@ -33,6 +33,7 @@ class ImportService extends ConfigurableService
 {
     const SERVICE_ID = 'taoSync/ImportService';
     const OPTION_IMPORTERS = 'importers';
+    const OPTION_IS_ENABLED = 'isEnabled';
 
     /** @var EntityImporterInterface[] */
     private $importers = [];

--- a/scripts/tool/Export/EnableSynchronizationExport.php
+++ b/scripts/tool/Export/EnableSynchronizationExport.php
@@ -26,7 +26,7 @@ use oat\taoSync\model\Export\ExportService;
 /**
  * Enables synchronization package export
  *
- * sudo -u www-data php index.php '\oat\taoSync\scripts\tool\Export\EnableSynchronizationExport'
+ * php index.php '\oat\taoSync\scripts\tool\Export\EnableSynchronizationExport'
  */
 class EnableSynchronizationExport extends InstallAction
 {

--- a/scripts/tool/Import/EnableSynchronizationImport.php
+++ b/scripts/tool/Import/EnableSynchronizationImport.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSync\scripts\tool\Import;
+
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoSync\model\import\ImportService;
+
+/**
+ * Enables synchronization package import
+ *
+ * sudo -u www-data php index.php '\oat\taoSync\scripts\tool\Import\EnableSynchronizationImport'
+ */
+class EnableSynchronizationImport extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $importService = $this->getImportService();
+        $importService->setOption(ImportService::OPTION_IS_ENABLED, true);
+        $this->registerService(ImportService::SERVICE_ID, $importService);
+
+        return \common_report_Report::createSuccess('Synchronization package import enabled.');
+    }
+
+    /**
+     * @return ImportService
+     */
+    protected function getImportService()
+    {
+        return $this->getServiceLocator()->get(ImportService::SERVICE_ID);
+    }
+}

--- a/scripts/tool/Import/EnableSynchronizationImport.php
+++ b/scripts/tool/Import/EnableSynchronizationImport.php
@@ -26,7 +26,7 @@ use oat\taoSync\model\import\ImportService;
 /**
  * Enables synchronization package import
  *
- * sudo -u www-data php index.php '\oat\taoSync\scripts\tool\Import\EnableSynchronizationImport'
+ * php index.php '\oat\taoSync\scripts\tool\Import\EnableSynchronizationImport'
  */
 class EnableSynchronizationImport extends InstallAction
 {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -814,6 +814,15 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('6.9.0', '6.11.0');
+
+        if ($this->isVersion('6.11.0')) {
+            $importService = $this->getServiceManager()->get(ImportService::SERVICE_ID);
+            $options = $importService->getOptions();
+            $options[ImportService::OPTION_IS_ENABLED] = false;
+            $this->getServiceManager()->register(ImportService::SERVICE_ID, $importService);
+
+            $this->setVersion('6.12.0');
+        }
     }
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8665
Added option to enable ImportService.
can be tested with : `sudo -u www-data php index.php '\oat\taoSync\scripts\tool\Import\EnableSynchronizationImport'`