### PR TITLE
[TAO-8706][FE] DEPP - 19EVA2-19EVA6 - Interface for importing a sync file when sync fails

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.12.0',
+    'version' => '6.13.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -823,6 +823,8 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('6.12.0');
         }
+
+        $this->skip('6.12.0', '6.13.0');
     }
 
     /**

--- a/views/js/controller/synchronizer/index.js
+++ b/views/js/controller/synchronizer/index.js
@@ -69,6 +69,8 @@ define([
      */
     var exportTaskName = 'oat\\taoSync\\scripts\\tool\\Export\\ExportSynchronizationPackage';
 
+    var importTaskName = 'oat\\taoSync\\scripts\\tool\\Import\\ImportSynchronizationPackage';
+
     /**
      * Default notification messages
      * @type {Object}
@@ -167,8 +169,10 @@ define([
             }).on('pollSingleFinished', function (taskId, taskData) {
                 if (taskData.status === 'completed') {
                     if (taskData.taskName === exportTaskName) {
-                        setState('form');
+                        setState('success', __('Synchronization data is ready to be downloaded. Downloading process will start in the background.'));
                         taskQueue.download(taskId);
+                    } else if (taskData.taskName === importTaskName) {
+                        setState('success', __('Synchronization data has been imported.'), true);
                     } else {
                         setState('success');
                         updateTime(taskData);
@@ -231,7 +235,7 @@ define([
              *
              * @param {String} state
              */
-            function setState(state, message) {
+            function setState(state, message, hideDashboard) {
                 var statusClassName = '.status-' + state;
                 var $messageContainer = $container.find(statusClassName + ' .messages p span:first-child');
                 $messageContainer.text(message || defaultSyncMessages[state]);
@@ -244,7 +248,7 @@ define([
                 $container.addClass('state-' + state);
                 msg.$all.hide();
 
-                if (state === 'success' || state === 'error') {
+                if ((state === 'success' || state === 'error') && !hideDashboard) {
                     renderReadinessDashboard();
                 } else if (state === 'progress') {
                     readinessDashboard && readinessDashboard.destroy();
@@ -411,7 +415,7 @@ define([
                     return;
                 }
 
-                setState('progress');
+                setState('progress', __('Import of synchronization data is in progress.'));
 
                 $syncForm.sendfile({
                     url: webservices.importSyncData,

--- a/views/templates/sync/index.tpl
+++ b/views/templates/sync/index.tpl
@@ -110,7 +110,9 @@ $formFields = get_data('form-fields');
                       <a class="export-link" data-control="export">
                           <?= __('Export Results') ?>
                       </a>
+                  <?php endif; ?>
 
+                  <?php if($isImportEnabled): ?>
                       <label class="import-label" for="syncPackage"><?= __('Import Results') ?></label>
                       <input class="import-file-input" type="file" name="syncPackage" id="syncPackage" data-control="import" accept=".zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed" />
                   <?php endif; ?>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8706
 
Separate import and export functionality

#### How to test
 
- install test center and offline instances of `DEPP` extension using seed files from https://oat-sa.atlassian.net/browse/TAO-8681 and develop version of extensions
- enable export on offline instance and import on test center instance
- create a test center with an assigned sync manager and some delivery and assigned test taker
- login into offline instance as a sync manager
- run synchronization
- after first synchronization login as test taker assigned to test center and execute assigned delivery
- when synchronization fails, click export button
- zip with sync data should be downloaded at the end of the preparation data process
- login to test center instance and navigate to synchronization form
- click on import button
- after import finished navigate to results tab and verify that all test results has been imported