### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'version' => '6.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'generis'         => '>=7.9.5',
+        'generis'         => '>=12.5.0',
         'tao'             => '>=38.8.0',
         'taoOauth'        => '>=2.0.0',
         'taoTestCenter'   => '>=4.6.0',

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.13.2',
+    'version' => '6.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.14.0',
+    'version' => '7.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -824,7 +824,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.12.0');
         }
 
-        $this->skip('6.12.0', '6.14.0');
+        $this->skip('6.12.0', '7.0.0');
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -824,7 +824,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.12.0');
         }
 
-        $this->skip('6.12.0', '6.13.2');
+        $this->skip('6.12.0', '6.14.0');
     }
 
     /**

--- a/test/User/HandShakeAuthAdapterTest.php
+++ b/test/User/HandShakeAuthAdapterTest.php
@@ -22,8 +22,9 @@ namespace oat\taoSync\test\User;
 
 use core_kernel_users_InvalidLoginException;
 use oat\taoSync\model\User\HandShakeAuthAdapter;
+use oat\generis\test\TestCase;
 
-class HandShakeAuthAdapterTest extends \PHPUnit_Framework_TestCase
+class HandShakeAuthAdapterTest extends TestCase
 {
     /**
      * @throws \Exception

--- a/test/User/HandShakeClientRequestTest.php
+++ b/test/User/HandShakeClientRequestTest.php
@@ -21,8 +21,9 @@
 namespace oat\taoSync\test\User;
 
 use oat\taoSync\model\User\HandShakeClientRequest;
+use oat\generis\test\TestCase;
 
-class HandShakeClientRequestTest extends \PHPUnit_Framework_TestCase
+class HandShakeClientRequestTest extends TestCase
 {
     public function testBuilding()
     {

--- a/test/User/HandShakeClientServiceTest.php
+++ b/test/User/HandShakeClientServiceTest.php
@@ -34,16 +34,17 @@ use oat\taoSync\model\User\HandShakeClientService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\MockObject;
 
 class HandShakeClientServiceTest extends TestCase
 {
     /**
-     * @var PublishingService|\PHPUnit_Framework_MockObject_MockObject
+     * @var PublishingService|MockObject
      */
     private $publishingServiceMock;
 
     /**
-     * @var PlatformService|\PHPUnit_Framework_MockObject_MockObject
+     * @var PlatformService|MockObject
      */
     private $platformServiceMock;
 
@@ -220,7 +221,7 @@ class HandShakeClientServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {
@@ -237,7 +238,7 @@ class HandShakeClientServiceTest extends TestCase
 
     /**
      * @param $resource
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockPlatformService($resource)
     {
@@ -251,7 +252,7 @@ class HandShakeClientServiceTest extends TestCase
 
     /**
      * @param $returnValue
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockPublishingService($returnValue)
     {
@@ -264,7 +265,7 @@ class HandShakeClientServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockFileSystem($handShakeDone = 0, $alwaysRemoteLogin = null)
     {
@@ -298,7 +299,7 @@ class HandShakeClientServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockProperty()
     {
@@ -306,7 +307,7 @@ class HandShakeClientServiceTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function getRequest()
     {

--- a/test/server/HandShakeServerEventTest.php
+++ b/test/server/HandShakeServerEventTest.php
@@ -22,8 +22,10 @@ namespace oat\taoSync\test\server;
 
 use core_kernel_classes_Resource;
 use oat\taoSync\model\server\HandShakeServerEvent;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class HandShakeServerEventTest extends \PHPUnit_Framework_TestCase
+class HandShakeServerEventTest extends TestCase
 {
     public function testEvent()
     {
@@ -35,7 +37,7 @@ class HandShakeServerEventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {

--- a/test/server/HandShakeServerResponseTest.php
+++ b/test/server/HandShakeServerResponseTest.php
@@ -25,8 +25,10 @@ use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\taoSync\model\formatter\SynchronizerFormatter;
 use oat\taoSync\model\server\HandShakeServerResponse;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class HandShakeServerResponseTest extends \PHPUnit_Framework_TestCase
+class HandShakeServerResponseTest extends TestCase
 {
     public function testAsArray()
     {
@@ -46,7 +48,7 @@ class HandShakeServerResponseTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {
@@ -89,7 +91,7 @@ class HandShakeServerResponseTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockModel()
     {

--- a/test/server/HandShakeServerServiceTest.php
+++ b/test/server/HandShakeServerServiceTest.php
@@ -30,8 +30,10 @@ use oat\taoSync\model\synchronizer\Synchronizer;
 use oat\taoSync\model\SyncService;
 use oat\taoSync\scripts\tool\oauth\GenerateOauthCredentials;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
+class HandShakeServerServiceTest extends TestCase
 {
     public function testHandShakeReceive()
     {
@@ -88,7 +90,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockGenerator()
     {
@@ -102,7 +104,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockProperty()
     {
@@ -110,7 +112,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockSyncService()
     {
@@ -138,7 +140,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource($roles = [])
     {
@@ -152,7 +154,7 @@ class HandShakeServerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockEventManager()
     {

--- a/test/unit/Execution/DeliveryExecutionStatusManagerTest.php
+++ b/test/unit/Execution/DeliveryExecutionStatusManagerTest.php
@@ -29,26 +29,27 @@ use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoSync\model\Execution\DeliveryExecutionStatusManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\MockObject;
 
 class DeliveryExecutionStatusManagerTest extends TestCase
 {
     /**
-     * @var ServiceLocatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ServiceLocatorInterface|MockObject
      */
     private $serviceLocatorMock;
 
     /**
-     * @var DeliveryMonitoringService|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeliveryMonitoringService|MockObject
      */
     private $deliveryMonitoringMock;
 
     /**
-     * @var ServiceProxy|\PHPUnit_Framework_MockObject_MockObject
+     * @var ServiceProxy|MockObject
      */
     private $serviceProxyMock;
 
     /**
-     * @var DeliveryExecutionStateService|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeliveryExecutionStateService|MockObject
      */
     private $deliveryExecutionStateMock;
 

--- a/test/unit/Export/ExportServiceTest.php
+++ b/test/unit/Export/ExportServiceTest.php
@@ -25,19 +25,20 @@ use oat\taoSync\model\Export\Exporter\ResultsExporter;
 use oat\taoSync\model\Export\ExportService;
 use oat\taoSync\model\Packager\PackagerInterface;
 use oat\taoSync\model\Packager\ZipPackager;
+use oat\generis\test\MockObject;
 
 class ExportServiceTest extends TestCase
 {
     /** @var ExportService */
     private $service;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     private $resultsExporterMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     private $packagerMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     private $loggerMock;
 
     public function setUp()

--- a/test/unit/SyncLog/SyncLogServiceTest.php
+++ b/test/unit/SyncLog/SyncLogServiceTest.php
@@ -25,6 +25,7 @@ use oat\taoSync\model\SyncLog\Storage\SyncLogStorageInterface;
 use oat\taoSync\model\SyncLog\SyncLogEntity;
 use oat\taoSync\model\SyncLog\SyncLogService;
 use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
+use oat\generis\test\MockObject;
 
 class SyncLogServiceTest extends TestCase
 {
@@ -36,7 +37,7 @@ class SyncLogServiceTest extends TestCase
     private $object;
 
     /**
-     * @var SyncLogStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SyncLogStorageInterface|MockObject
      */
     private $storageMock;
 

--- a/test/unit/SynchronizationHistory/SynchronizationHistoryServiceTest.php
+++ b/test/unit/SynchronizationHistory/SynchronizationHistoryServiceTest.php
@@ -30,6 +30,7 @@ use oat\taoSync\model\SynchronizationHistory\SynchronizationHistoryService;
 use oat\generis\test\TestCase;
 use oat\taoSync\model\SyncLog\SyncLogEntity;
 use oat\taoSync\model\SyncLog\SyncLogServiceInterface;
+use oat\generis\test\MockObject;
 
 class SynchronizationHistoryServiceTest extends TestCase
 {
@@ -39,12 +40,12 @@ class SynchronizationHistoryServiceTest extends TestCase
     private $object;
 
     /**
-     * @var HistoryPayloadFormatter|\PHPUnit_Framework_MockObject_MockObject
+     * @var HistoryPayloadFormatter|MockObject
      */
     private $formatterMock;
 
     /**
-     * @var SyncLogServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SyncLogServiceInterface|MockObject
      */
     private $syncLogServiceMock;
 

--- a/test/unit/Validator/SyncParamsValidatorTest.php
+++ b/test/unit/Validator/SyncParamsValidatorTest.php
@@ -23,6 +23,7 @@ use oat\generis\test\TestCase;
 use oat\taoSync\model\Exception\SyncRequestFailedException;
 use oat\taoSync\model\Validator\SyncParamsValidator;
 use oat\taoSync\model\VirtualMachine\SupportedVmService;
+use oat\generis\test\MockObject;
 
 class SyncParamsValidatorTest extends TestCase
 {
@@ -32,7 +33,7 @@ class SyncParamsValidatorTest extends TestCase
     private $object;
 
     /**
-     * @var SupportedVmService|\PHPUnit_Framework_MockObject_MockObject
+     * @var SupportedVmService|MockObject
      */
     private $supportedVmServiceMock;
 

--- a/test/unit/VirtualMachine/SupportedVmServiceTest.php
+++ b/test/unit/VirtualMachine/SupportedVmServiceTest.php
@@ -25,6 +25,7 @@ use core_kernel_classes_Property;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\taoSync\model\VirtualMachine\SupportedVmService;
+use oat\generis\test\MockObject;
 
 class SupportedVmServiceTest extends TestCase
 {
@@ -34,12 +35,12 @@ class SupportedVmServiceTest extends TestCase
     private $object;
 
     /**
-     * @var Ontology|\PHPUnit_Framework_MockObject_MockObject
+     * @var Ontology|MockObject
      */
     private $modelMock;
 
     /**
-     * @var core_kernel_classes_Class|\PHPUnit_Framework_MockObject_MockObject
+     * @var core_kernel_classes_Class|MockObject
      */
     private $rootClassMock;
 

--- a/test/unit/VirtualMachine/VmIdentifierServiceTest.php
+++ b/test/unit/VirtualMachine/VmIdentifierServiceTest.php
@@ -22,6 +22,7 @@ namespace oat\taoSync\test\unit\VirtualMachine;
 use oat\generis\test\TestCase;
 use oat\taoPublishing\model\publishing\PublishingService;
 use oat\taoSync\model\VirtualMachine\VmIdentifierService;
+use oat\generis\test\MockObject;
 
 class VmIdentifierServiceTest extends TestCase
 {
@@ -31,7 +32,7 @@ class VmIdentifierServiceTest extends TestCase
     private $object;
 
     /**
-     * @var PublishingService|\PHPUnit_Framework_MockObject_MockObject
+     * @var PublishingService|MockObject
      */
     private $publishingServiceMock;
 

--- a/test/unit/formatter/FormatterServiceTest.php
+++ b/test/unit/formatter/FormatterServiceTest.php
@@ -20,6 +20,7 @@
 namespace oat\taoSync\test\unit\formatter;
 
 use oat\taoSync\model\formatter\FormatterService;
+use oat\generis\test\MockObject;
 
 class FormatterServiceTest extends \oat\generis\test\TestCase
 {
@@ -113,7 +114,7 @@ class FormatterServiceTest extends \oat\generis\test\TestCase
     /**
      * @param string $uri
      * @param \core_kernel_classes_ContainerCollection $collectionOfTriples
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     private function mockResource($uri, $collectionOfTriples)
     {

--- a/test/unit/listener/SyncStatusListenerTest.php
+++ b/test/unit/listener/SyncStatusListenerTest.php
@@ -26,6 +26,7 @@ use oat\taoSync\model\client\SynchronisationClient;
 use oat\taoSync\model\event\SyncFailedEvent;
 use oat\taoSync\model\listener\SyncStatusListener;
 use Psr\Log\LoggerInterface;
+use oat\generis\test\MockObject;
 
 class SyncStatusListenerTest extends TestCase
 {
@@ -35,12 +36,12 @@ class SyncStatusListenerTest extends TestCase
     private $object;
 
     /**
-     * @var SynchronisationClient|\PHPUnit_Framework_MockObject_MockObject
+     * @var SynchronisationClient|MockObject
      */
     private $syncClientMock;
 
     /**
-     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var LoggerInterface|MockObject
      */
     private $loggerMock;
 

--- a/test/unit/tool/synchronisation/SynchronizeAllTest.php
+++ b/test/unit/tool/synchronisation/SynchronizeAllTest.php
@@ -33,32 +33,32 @@ use oat\taoSync\model\event\SyncStartedEvent;
 use oat\taoSync\model\history\DataSyncHistoryService;
 use oat\taoSync\model\VirtualMachine\VmVersionChecker;
 use oat\taoSync\scripts\tool\synchronisation\SynchronizeAll;
-use PHPUnit_Framework_MockObject_MockObject;
+use oat\generis\test\MockObject;
 
 class SynchronizeAllTest extends TestCase implements Action
 {
     /**
-     * @var EventManager|PHPUnit_Framework_MockObject_MockObject
+     * @var EventManager|MockObject
      */
     private $eventManagerMock;
 
     /**
-     * @var ApplicationService|PHPUnit_Framework_MockObject_MockObject
+     * @var ApplicationService|MockObject
      */
     private $applicationServiceMock;
 
     /**
-     * @var DataSyncHistoryService|PHPUnit_Framework_MockObject_MockObject
+     * @var DataSyncHistoryService|MockObject
      */
     private $dataSyncHistoryServiceMock;
 
     /**
-     * @var PublishingService|PHPUnit_Framework_MockObject_MockObject
+     * @var PublishingService|MockObject
      */
     private $publishingServiceMock;
 
     /**
-     * @var VmVersionChecker|PHPUnit_Framework_MockObject_MockObject
+     * @var VmVersionChecker|MockObject
      */
     private $vmVersionCheckerMock;
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.