### PR TITLE
Feature/dpf 451/resource checksum cache

### DIFF
--- a/config/default/EntityChecksumCacheService.conf.php
+++ b/config/default/EntityChecksumCacheService.conf.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+use oat\taoSync\model\EntityChecksumCacheService;
+
+return new EntityChecksumCacheService([
+    'persistence' => 'default_kv',
+]);
+

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Tao Sync',
     'description' => 'TAO synchronisation for offline client data.',
     'license' => 'GPL-2.0',
-    'version' => '6.13.0.2',
+    'version' => '6.13.0.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'         => '>=7.9.5',

--- a/model/EntityChecksumCacheService.php
+++ b/model/EntityChecksumCacheService.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoSync\model;
+
+use common_persistence_KeyValuePersistence;
+use common_persistence_Manager;
+use InvalidArgumentException;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoSync\model\synchronizer\AbstractResourceSynchronizer;
+
+class EntityChecksumCacheService extends ConfigurableService
+{
+    use OntologyAwareTrait;
+
+    public const SERVICE_ID = 'taoSync/EntityChecksumCacheService';
+    public const OPTION_PERSISTENCE = 'persistence';
+
+    private const PREFIX = 'entity-checksum-';
+
+    public function get(string $id)
+    {
+        return $this->getPersistence()->get($this->makeKey($id));
+    }
+
+    public function update(AbstractResourceSynchronizer $synchronizer, array $entityIds): void
+    {
+        foreach ($entityIds as $id) {
+            $formatted = $synchronizer->format($this->getResource($id));
+            $this->getPersistence()->set($this->makeKey($id), $formatted['checksum']);
+        }
+    }
+
+    public function delete(array $entityIds): void
+    {
+        foreach ($entityIds as $id) {
+            $this->getPersistence()->del($this->makeKey($id));
+        }
+    }
+
+    private function makeKey(string $id): string
+    {
+        return self::PREFIX . $id;
+    }
+
+    /**
+     * @return common_persistence_KeyValuePersistence
+     */
+    private function getPersistence()
+    {
+        if (!$this->hasOption(self::OPTION_PERSISTENCE)) {
+            throw new InvalidArgumentException('Persistence for ' . self::SERVICE_ID . ' is not configured');
+        }
+
+        $persistenceId = $this->getOption(self::OPTION_PERSISTENCE);
+
+        return $this->getServiceLocator()->get(common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
+    }
+}

--- a/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
+++ b/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
@@ -43,7 +43,7 @@ trait OrganisationIdTrait
     protected function getOrganisationIdFromOption(array $options = [])
     {
         if (!isset($options[TestCenterByOrganisationId::OPTION_ORGANISATION_ID])) {
-            $ids = \common_session_SessionManager::getSession()->getUserPropertyValues($this->getProperty(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY));
+            $ids = \common_session_SessionManager::getSession()->getUserPropertyValues(TestCenterByOrganisationId::ORGANISATION_ID_PROPERTY);
             $id = reset($ids);
             if (empty($id)) {
                 $this->logError('Organisation id cannot be retrieved from parameters. Current synchronisation aborted.');

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -42,6 +42,7 @@ use oat\taoSync\model\DeliveryLog\DeliveryLogFormatterService;
 use oat\taoSync\model\DeliveryLog\EnhancedDeliveryLogService;
 use oat\taoSync\model\DeliveryLog\SyncDeliveryLogService;
 use oat\taoSync\model\Entity;
+use oat\taoSync\model\EntityChecksumCacheService;
 use oat\taoSync\model\event\SyncFailedEvent;
 use oat\taoSync\model\event\SyncFinishedEvent;
 use oat\taoSync\model\event\SyncRequestEvent;
@@ -825,6 +826,15 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('6.12.0', '6.13.0.2');
+
+        if ($this->isVersion('6.13.0.2')) {
+            $service = new EntityChecksumCacheService([
+                EntityChecksumCacheService::OPTION_PERSISTENCE => 'default_kv',
+            ]);
+            $this->getServiceManager()->register(EntityChecksumCacheService::SERVICE_ID, $service);
+
+            $this->setVersion('6.13.0.3');
+        }
     }
 
     /**

--- a/test/unit/EntityChecksumCacheServiceTest.php
+++ b/test/unit/EntityChecksumCacheServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoSync\test\unit;
+
+use common_persistence_KeyValuePersistence;
+use common_persistence_Manager;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\TestCase;
+use oat\taoSync\model\EntityChecksumCacheService;
+use oat\taoSync\model\synchronizer\AbstractResourceSynchronizer;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class EntityChecksumCacheServiceTest extends TestCase
+{
+    /** @var EntityChecksumCacheService */
+    private $service;
+
+    /** @var common_persistence_KeyValuePersistence|PHPUnit_Framework_MockObject_MockObject */
+    private $persistenceMock;
+
+    /** @var Ontology|PHPUnit_Framework_MockObject_MockObject */
+    private $ontologyMock;
+
+    public function setUp(): void
+    {
+        $this->persistenceMock = $this->createMock(common_persistence_KeyValuePersistence::class);
+        $persistenceManagerMock = $this->createMock(common_persistence_Manager::class);
+        $persistenceManagerMock->method('getPersistenceById')->willReturn($this->persistenceMock);
+        $serviceLocatorMock = $this->getServiceLocatorMock([
+            common_persistence_Manager::SERVICE_ID => $persistenceManagerMock,
+        ]);
+        $this->ontologyMock = $this->createMock(Ontology::class);
+        $this->service = new EntityChecksumCacheService([
+            'persistence' => 'default'
+        ]);
+        $this->service->setServiceLocator($serviceLocatorMock);
+        $this->service->setModel($this->ontologyMock);
+    }
+
+    public function testGet_WhenPersistenceNotConfigured_ThenExceptionThrown(): void
+    {
+        $this->service->setOptions([]);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->service->get('RANDOM_URI');
+    }
+
+    public function testGet_WhenPersistenceConfigured_ThenFoundValueIsReturned(): void
+    {
+        $cachedChecksum = 'CACHED_CHECKSUM';
+        $this->persistenceMock->expects($this->once())->method('get')->willReturn($cachedChecksum);
+        $this->assertSame($cachedChecksum, $this->service->get('RANDOM_URI'));
+    }
+
+    public function testUpdate_WhenEntityIdListProvided_ThenSynchronizerFormattedChecksumsAreStored()
+    {
+        $this->ontologyMock->method('getResource')
+            ->willReturn($this->createMock(core_kernel_classes_Resource::class));
+        $synchronizerMock = $this->createMock(AbstractResourceSynchronizer::class);
+        $synchronizerMock->method('format')
+            ->willReturn(['checksum' => 'TEST CHECKSUM']);
+
+        $this->persistenceMock->expects($this->exactly(2))->method('set');
+        $this->service->update($synchronizerMock, ['URI1', 'URI2']);
+    }
+
+    public function testDelete_WhenEntityIdListProvided_ThenEachIsRemovedFromPersistence()
+    {
+        $this->persistenceMock->expects($this->exactly(2))->method('del');
+        $this->service->delete(['URI1', 'URI2']);
+    }
+}


### PR DESCRIPTION
Checksum cache to avoid database queries
 
Related to : https://oat-sa.atlassian.net/browse/DPF-451
 
During resource synchronization, checksum cache is consulted before looking for the record and properties in database. Cache is populated when synchronized entities are persisted to DB, created or updated.
 
#### How to test
 
 - Configure central and client server instances with sprint 109
 - In central server prepare test, delivery, test center, proctor, sync manager, test takers, configure eligibilities
 - In client server connect with sync manager and launch synchronization
 - Launch the synchronization again and check that no entities were synced and that there were less database queries
 
Test commands :
 
```
sudo -u www-data ./vendor/bin/phpunit taoSync/test/unit/EntityChecksumCacheServiceTest.php
```