### PR TITLE
Feature TR-1935: offset-based chunked data synchronization

### DIFF
--- a/model/SyncService.php
+++ b/model/SyncService.php
@@ -436,7 +436,7 @@ class SyncService extends ConfigurableService
     /**
      * Get all available synchronizer from the config
      *
-     * @return Synchronizer[]
+     * @return string[]
      */
     protected function getAllTypes()
     {

--- a/model/SyncService.php
+++ b/model/SyncService.php
@@ -129,21 +129,16 @@ class SyncService extends ConfigurableService
             OntologyRdfs::RDFS_LABEL => 'asc',
         ];
 
-        $limit = $this->getChunkSize() + 1;
+        $limit = $this->getChunkSize();
         $options['limit'] = $limit;
-
-        if (isset($options['nextResource'])) {
-            $startEpoch = $this->getSynchronizer($type)->getEntityProperty($options['nextResource'], Entity::CREATED_AT);
-            if (!is_null($startEpoch)) {
-                $options['startCreatedAt'] = $startEpoch;
-            }
+        if (!isset($options['offset'])) {
+            $options['offset'] = 0;
         }
 
         $entities = $this->getSynchronizer($type)->fetch($options);
 
-        if (count($entities) == $limit) {
-            $nextEntity = array_pop($entities);
-            $params['nextResource'] = $nextEntity['id'];
+        if (count($entities) === $limit) {
+            $params['offset'] = $options['offset'] + $limit;
             $response['nextCallUrl'] = '/taoSync/SynchronisationApi/fetchEntityChecksums?' . http_build_query([
                 SynchronisationApi::PARAM_TYPE => $type,
                 SynchronisationApi::PARAM_PARAMETERS => $params,

--- a/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
+++ b/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
@@ -30,6 +30,8 @@ use oat\taoTestCenter\model\TestCenterService;
 
 trait OrganisationIdTrait
 {
+    private $eligibilities = [];
+
     abstract public function getServiceLocator();
 
     /**
@@ -93,6 +95,10 @@ trait OrganisationIdTrait
      */
     protected function getEligibilitiesByOrganisationId($orgId)
     {
+        if (isset($this->eligibilities[$orgId])) {
+            return $this->eligibilities[$orgId];
+        }
+
         /** @var ComplexSearchService $search */
         $search = $this->getServiceLocator()->get(ComplexSearchService::SERVICE_ID);
 
@@ -119,6 +125,8 @@ trait OrganisationIdTrait
                 $values[$resource->getUri()] = $resource;
             }
         }
+
+        $this->eligibilities[$orgId] = $values;
 
         return $values;
     }

--- a/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
+++ b/model/synchronizer/custom/byOrganisationId/OrganisationIdTrait.php
@@ -24,7 +24,6 @@ namespace oat\taoSync\model\synchronizer\custom\byOrganisationId;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\kernel\persistence\smoothsql\search\QueryJoiner;
 use oat\search\base\exception\SearchGateWayExeption;
-use oat\taoSync\model\Entity;
 use oat\taoSync\model\synchronizer\custom\byOrganisationId\testcenter\TestCenterByOrganisationId;
 use oat\taoTestCenter\model\EligibilityService;
 use oat\taoTestCenter\model\TestCenterService;
@@ -127,45 +126,18 @@ trait OrganisationIdTrait
     /**
      * Post apply options in $params to set of resources
      *
-     * @param $resources
-     * @param $params
+     * @param \core_kernel_classes_Resource[] $resources
+     * @param array $params
      * @return array
      * @throws \common_Exception
      */
     protected function postApplyQueryOptions($resources, $params)
     {
-        $sortedInstances = $values = [];
-        $withProperties = isset($params['withProperties']) && (int) $params['withProperties'] == 1;
-        /** @var \core_kernel_classes_Resource $resource */
+        $withProperties = isset($params['withProperties']) && (int)$params['withProperties'] === 1;
+        $values = [];
+
         foreach ($resources as $resource) {
-            if (!$resource->exists()) {
-                continue;
-            }
-            $createdAt = $resource->getUniquePropertyValue($this->getProperty(Entity::CREATED_AT))->literal;
-            $sortedInstances[$createdAt] = $this->format($resource, $withProperties, $params);
-        }
-
-        ksort($sortedInstances);
-
-        $startCreatedAt = isset($params['startCreatedAt']) ? $params['startCreatedAt'] : false;
-        $limit = isset($params['limit']) ? $params['limit'] : false;
-        $offset = isset($params['offset']) ? $params['offset'] : 0;
-
-        $current = 1;
-        foreach ($sortedInstances as $createdAt => $instance) {
-            if ($startCreatedAt !== false && $createdAt < $startCreatedAt) {
-                continue;
-            }
-            if ($current < $offset) {
-                continue;
-            }
-
-            $values[$instance['id']] = $instance;
-
-            if ($limit !== false && ($current - $offset) == $limit) {
-                break;
-            }
-            $current++;
+            $values[$resource->getUri()] = $this->format($resource, $withProperties, $params);
         }
 
         return $values;

--- a/model/synchronizer/custom/byOrganisationId/user/TestTakerByOrganisationId.php
+++ b/model/synchronizer/custom/byOrganisationId/user/TestTakerByOrganisationId.php
@@ -54,6 +54,10 @@ class TestTakerByOrganisationId extends RdfTestTakerSynchronizer
             }
         }
 
+        $limit = $params['limit'] ?? 100;
+        $offset = $params['offset'] ?? 0;
+        $testtakerResources = array_slice($testtakerResources, $offset, $limit);
+
         return $this->postApplyQueryOptions($testtakerResources, $params);
     }
 }


### PR DESCRIPTION
# [TR-1935](https://oat-sa.atlassian.net/browse/TR-1935)

This PR attempts to forward-port crucial features, introduced by [v6.13.0.1](https://github.com/oat-sa/extension-tao-sync/compare/v6.13.0...v6.13.0.1).

- fix: `SyncService::getAllTypes()` DocBlock
- feat: offset-based chunked data synchronization
- feat: runtime cache of eligibilities

### Backport counterpart ⬇️
[v7.7.0.2](https://github.com/oat-sa/extension-tao-sync/compare/v7.7.0.1...v7.7.0.2)