### PR TITLE
fix: call to DeliveryMonitoring should not have 3 args now

### DIFF
--- a/model/Execution/DeliveryExecutionStatusManager.php
+++ b/model/Execution/DeliveryExecutionStatusManager.php
@@ -57,7 +57,7 @@ class DeliveryExecutionStatusManager extends ConfigurableService
 
         return $deliveryMonitoringService->find([
             DeliveryMonitoringService::STATUS => $this->getNotFinalStatuses()
-        ], [], true);
+        ], []);
     }
 
 


### PR DESCRIPTION
The reason to have those changes is the same as in oat-sa/extension-tao-encryption#99 - to make sure that the taoSync receives updates according to the latest changes in taoProctoring extension